### PR TITLE
Update RichTextAlignmentWriter.swift

### DIFF
--- a/Sources/RichTextKit/Alignment/RichTextAlignmentWriter.swift
+++ b/Sources/RichTextKit/Alignment/RichTextAlignmentWriter.swift
@@ -126,8 +126,8 @@ private extension RichTextAlignmentWriter {
         style.alignment = alignment.nativeAlignment
         attributes[.paragraphStyle] = style
         text.beginEditing()
-        text.setAttributes(attributes, range: range)
-        text.fixAttributes(in: range)
+        text.setAttributes(attributes, range: safeRange)
+        text.fixAttributes(in: safeRange)
         text.endEditing()
     }
 


### PR DESCRIPTION
RichTextAlignmentWriter was crashing due to using unsafe range. Updated setAttributes and fixAttributes to use safeRange.