### PR TITLE
Wrap RichTextCoordinator.syncContextWithTextView() in DispatchQueue

### DIFF
--- a/Sources/RichTextKit/RichTextCoordinator.swift
+++ b/Sources/RichTextKit/RichTextCoordinator.swift
@@ -163,19 +163,21 @@ extension RichTextCoordinator {
      */
     func syncContextWithTextView() {
         let styles = textView.currentRichTextStyles
-        context.alignment = textView.currentRichTextAlignment ?? .left
-        context.backgroundColor = textView.currentBackgroundColor
-        context.canCopy = textView.hasSelectedRange
-        context.canRedoLatestChange = textView.undoManager?.canRedo ?? false
-        context.canUndoLatestChange = textView.undoManager?.canUndo ?? false
-        context.fontName = textView.currentFontName ?? ""
-        context.fontSize = textView.currentFontSize ?? .standardRichTextFontSize
-        context.foregroundColor = textView.currentForegroundColor
-        context.isBold = styles.hasStyle(.bold)
-        context.isItalic = styles.hasStyle(.italic)
-        context.isUnderlined = styles.hasStyle(.underlined)
-        context.isEditingText = textView.isFirstResponder
-        context.selectedRange = textView.selectedRange
+        DispatchQueue.main.async {
+            context.alignment = textView.currentRichTextAlignment ?? .left
+            context.backgroundColor = textView.currentBackgroundColor
+            context.canCopy = textView.hasSelectedRange
+            context.canRedoLatestChange = textView.undoManager?.canRedo ?? false
+            context.canUndoLatestChange = textView.undoManager?.canUndo ?? false
+            context.fontName = textView.currentFontName ?? ""
+            context.fontSize = textView.currentFontSize ?? .standardRichTextFontSize
+            context.foregroundColor = textView.currentForegroundColor
+            context.isBold = styles.hasStyle(.bold)
+            context.isItalic = styles.hasStyle(.italic)
+            context.isUnderlined = styles.hasStyle(.underlined)
+            context.isEditingText = textView.isFirstResponder
+            context.selectedRange = textView.selectedRange
+        }
         updateTextViewAttributesIfNeeded()
     }
 


### PR DESCRIPTION
<img width="1403" alt="image" src="https://user-images.githubusercontent.com/23061765/199227205-dd7272c6-8550-42eb-b0e8-9fc652122903.png">
Xcode 14 produces runtime warnings for this function, as it updates the UI from a background thread.
This PR wraps the function in `DispatchQueue.main.async`. An alternative would be to use `@MainActor`.

This PR should get tested before merging!