### PR TITLE
Add to updateUIView

### DIFF
--- a/Sources/RichTextKit/RichTextEditor.swift
+++ b/Sources/RichTextKit/RichTextEditor.swift
@@ -84,7 +84,9 @@ public struct RichTextEditor: ViewRepresentable {
         return textView
     }
 
-    public func updateUIView(_ view: UIViewType, context: Context) {}
+    public func updateUIView(_ view: UIViewType, context: Context) {
+        textView.attributedString = text.wrappedValue
+    }
     #endif
 
     #if os(macOS)


### PR DESCRIPTION
Currently the updateUIView method on RichTextEditor is empty. This means if someone tries to update the Binded text externally, it will not update the text within the internal textView. ie: 

```
@State var text = NSAttributedString()

var body: some View {
     RichTextEditor(text: $text, context: context)
          .onAppear { text = NSAttributedString(string: "New String") } // This will now update the textView
}
```