### PR TITLE
Some enhancements related to pasting images

### DIFF
--- a/Sources/RichTextKit/RichTextView_AppKit.swift
+++ b/Sources/RichTextKit/RichTextView_AppKit.swift
@@ -226,4 +226,15 @@ public extension RichTextView {
         textStorage
     }
 }
+
+// MARK: - Additional Pasteboard Types
+
+public extension RichTextView {
+    override var readablePasteboardTypes: [NSPasteboard.PasteboardType] {
+        var pasteboardTypes = super.readablePasteboardTypes
+        pasteboardTypes.append(.png)
+        return pasteboardTypes
+    }
+}
+
 #endif

--- a/Sources/RichTextKit/RichTextView_AppKit.swift
+++ b/Sources/RichTextKit/RichTextView_AppKit.swift
@@ -61,6 +61,23 @@ open class RichTextView: NSTextView, RichTextViewComponent {
             pasteImages(images, at: selectedRange().location, moveCursorToPastedContent: true)
             return true
         }
+        // Handle fileURLs that contain known image types
+        let images = pasteboard.pasteboardItems?.compactMap {
+            if let str = $0.string(forType: NSPasteboard.PasteboardType.fileURL),
+               let url = URL(string: str), let image = ImageRepresentable(contentsOf: url) {
+                let fileExtension = url.pathExtension.lowercased()
+                let imageExtensions = ["jpg", "jpeg", "png", "gif", "tiff", "bmp", "heic"]
+                if imageExtensions.contains(fileExtension) {
+                    return image
+                }
+            }
+            return nil
+        } ?? [ImageRepresentable]()
+        if images.count > 0 {
+            pasteImages(images, at: selectedRange().location, moveCursorToPastedContent: true)
+            return true
+        }
+        
         return super.performDragOperation(draggingInfo)
     }
 


### PR DESCRIPTION
Two additions primarily focused on macOS:

- Dragging and dropping images from the finder did not work because those come in as fileURLs.
- Additional readablePasteboardTypes allow pasting PNGs. (For example screenshots)

Thanks for RichTextKit!  I'm looking forward to trying it out further now that I can paste images more freely :)