### PR TITLE
Fix incorrect test name

### DIFF
--- a/Tests/RichTextKitTests/Fonts/FontRepresentable+RichTextTests.swift
+++ b/Tests/RichTextKitTests/Fonts/FontRepresentable+RichTextTests.swift
@@ -9,9 +9,8 @@
 import RichTextKit
 import XCTest
 
-class FontRepresentable_RichTextTests: XCTestCase {
-    
-    func textStandardRichTextFont() {
+final class FontRepresentable_RichTextTests: XCTestCase {
+    func testStandardRichTextFont() {
         let expected = FontRepresentable.systemFont(ofSize: .standardRichTextFontSize)
         XCTAssertEqual(FontRepresentable.standardRichTextFont, expected)
         FontRepresentable.standardRichTextFont = .standardRichTextFont


### PR DESCRIPTION
Test name was not correctly recognized, as it started with `text` instead of `test`.