### PR TITLE
Test improvements

### DIFF
--- a/Tests/RichTextKitTests/Attributes/RichTextAttributeReader+AlignmentTests.swift
+++ b/Tests/RichTextKitTests/Attributes/RichTextAttributeReader+AlignmentTests.swift
@@ -24,8 +24,4 @@ final class RichTextAttributeReader_AlignmentTests: XCTestCase {
     }
 }
 
-private class TestReader: RichTextAttributeReader {
-
-    var attributedString = NSAttributedString(string: "foo bar")
-}
 #endif

--- a/Tests/RichTextKitTests/Attributes/RichTextAttributeReaderWriterTests.swift
+++ b/Tests/RichTextKitTests/Attributes/RichTextAttributeReaderWriterTests.swift
@@ -11,7 +11,7 @@ import XCTest
 
 final class RichTextAttributeReaderWriterTests: XCTestCase {
 
-    let string = NSMutableAttributedString(string: "foo bar baz")
+    private let string = NSMutableAttributedString(string: "foo bar baz")
 
     func testSettingAttributeWithinRangeOnlySetsAttributeWithinTheProvidedRange() {
         let color = ColorRepresentable.yellow

--- a/Tests/RichTextKitTests/Data/RichTextDataFormatTests.swift
+++ b/Tests/RichTextKitTests/Data/RichTextDataFormatTests.swift
@@ -12,44 +12,42 @@ import XCTest
 
 final class RichTextDataFormatTests: XCTestCase {
 
-    let vendorType = UTType(exportedAs: "fooType")
+    private let vendorType = UTType(exportedAs: "fooType")
 
-    lazy var vendorFormat = RichTextDataFormat.vendorArchivedData(
+    private lazy var vendorFormat = RichTextDataFormat.vendorArchivedData(
         id: "foo",
         fileExtension: "fooFile",
         fileFormatText: "Foo File (*.foo)",
         uniformType: vendorType
     )
 
-    func idResult(for format: RichTextDataFormat) -> String {
+    private func idResult(for format: RichTextDataFormat) -> String {
         format.id
     }
 
-    func isArchivedDataResult(for format: RichTextDataFormat) -> Bool {
+    private func isArchivedDataResult(for format: RichTextDataFormat) -> Bool {
         format.isArchivedDataFormat
     }
 
-    func formatResult(for format: RichTextDataFormat) -> [RichTextDataFormat] {
+    private func formatResult(for format: RichTextDataFormat) -> [RichTextDataFormat] {
         format.convertibleFormats
     }
 
-    func extensionResult(for format: RichTextDataFormat) -> String {
+    private func extensionResult(for format: RichTextDataFormat) -> String {
         format.standardFileExtension
     }
 
-    func imageResult(for format: RichTextDataFormat) -> Bool {
+    private func imageResult(for format: RichTextDataFormat) -> Bool {
         format.supportsImages
     }
 
-    func uniformTypeResult(for format: RichTextDataFormat) -> UTType {
+    private func uniformTypeResult(for format: RichTextDataFormat) -> UTType {
         format.uniformType
     }
-
 
     func testLibraryFormatsReturnAllNonVendorFormats() {
         XCTAssertEqual(RichTextDataFormat.libraryFormats, [.archivedData, .plainText, .rtf])
     }
-
 
     func testIdIsValidForAllFormats() {
         XCTAssertEqual(idResult(for: .archivedData), "archivedData")
@@ -65,7 +63,7 @@ final class RichTextDataFormatTests: XCTestCase {
         XCTAssertEqual(isArchivedDataResult(for: vendorFormat), true)
     }
 
-    func testConvertableFormatsAreValidForAllFormats() {
+    func testConvertibleFormatsAreValidForAllFormats() {
         XCTAssertEqual(formatResult(for: .archivedData), [.plainText, .rtf])
         XCTAssertEqual(formatResult(for: .plainText), [.archivedData, .rtf])
         XCTAssertEqual(formatResult(for: .rtf), [.archivedData, .plainText])

--- a/Tests/RichTextKitTests/Data/RichTextDataFormatTests.swift
+++ b/Tests/RichTextKitTests/Data/RichTextDataFormatTests.swift
@@ -21,30 +21,6 @@ final class RichTextDataFormatTests: XCTestCase {
         uniformType: vendorType
     )
 
-    private func idResult(for format: RichTextDataFormat) -> String {
-        format.id
-    }
-
-    private func isArchivedDataResult(for format: RichTextDataFormat) -> Bool {
-        format.isArchivedDataFormat
-    }
-
-    private func formatResult(for format: RichTextDataFormat) -> [RichTextDataFormat] {
-        format.convertibleFormats
-    }
-
-    private func extensionResult(for format: RichTextDataFormat) -> String {
-        format.standardFileExtension
-    }
-
-    private func imageResult(for format: RichTextDataFormat) -> Bool {
-        format.supportsImages
-    }
-
-    private func uniformTypeResult(for format: RichTextDataFormat) -> UTType {
-        format.uniformType
-    }
-
     func testLibraryFormatsReturnAllNonVendorFormats() {
         XCTAssertEqual(RichTextDataFormat.libraryFormats, [.archivedData, .plainText, .rtf])
     }
@@ -89,5 +65,31 @@ final class RichTextDataFormatTests: XCTestCase {
         XCTAssertEqual(uniformTypeResult(for: .plainText), .plainText)
         XCTAssertEqual(uniformTypeResult(for: .rtf), .rtf)
         XCTAssertEqual(uniformTypeResult(for: vendorFormat), vendorType)
+    }
+}
+
+private extension RichTextDataFormatTests {
+    func idResult(for format: RichTextDataFormat) -> String {
+        format.id
+    }
+
+    func isArchivedDataResult(for format: RichTextDataFormat) -> Bool {
+        format.isArchivedDataFormat
+    }
+
+    func formatResult(for format: RichTextDataFormat) -> [RichTextDataFormat] {
+        format.convertibleFormats
+    }
+
+    func extensionResult(for format: RichTextDataFormat) -> String {
+        format.standardFileExtension
+    }
+
+    func imageResult(for format: RichTextDataFormat) -> Bool {
+        format.supportsImages
+    }
+
+    func uniformTypeResult(for format: RichTextDataFormat) -> UTType {
+        format.uniformType
     }
 }

--- a/Tests/RichTextKitTests/Extensions/NSAttributedString+EmptyTests.swift
+++ b/Tests/RichTextKitTests/Extensions/NSAttributedString+EmptyTests.swift
@@ -10,7 +10,6 @@ import RichTextKit
 import XCTest
 
 final class NSAttributedString_EmptyTests: XCTestCase {
-    
     func testEmptyAttributedString() {
         let string = NSAttributedString.empty
         XCTAssertEqual(string.string, "")

--- a/Tests/RichTextKitTests/Extensions/String+CharactersTests.swift
+++ b/Tests/RichTextKitTests/Extensions/String+CharactersTests.swift
@@ -10,7 +10,6 @@ import RichTextKit
 import XCTest
 
 final class String_CharactersTest: XCTestCase {
-    
     func testStringCharactersAreValid() {
         XCTAssertEqual(String.carriageReturn, "\r")
         XCTAssertEqual(String.newLine, "\n")

--- a/Tests/RichTextKitTests/Extensions/String+ParagraphTests.swift
+++ b/Tests/RichTextKitTests/Extensions/String+ParagraphTests.swift
@@ -15,14 +15,6 @@ final class String_ParagraphTests: XCTestCase {
     private let single = "foo\nbar baz"
     private let multi = "foo\nbar\rbaz"
 
-    private func currentResult(for string: String, from location: UInt) -> UInt {
-        string.findIndexOfCurrentParagraph(from: location)
-    }
-
-    private func nextResult(for string: String, from location: UInt) -> UInt {
-        string.findIndexOfNextParagraph(from: location)
-    }
-
     func testIndexOfCurrentParagraphIsCorrectForEmptyString() {
         XCTAssertEqual(currentResult(for: "", from: 0), 0)
         XCTAssertEqual(currentResult(for: "", from: 20), 0)
@@ -68,5 +60,15 @@ final class String_ParagraphTests: XCTestCase {
         XCTAssertEqual(nextResult(for: multi, from: 0), 4)
         XCTAssertEqual(nextResult(for: multi, from: 5), 8)
         XCTAssertEqual(nextResult(for: multi, from: 10), 8)
+    }
+}
+
+private extension String_ParagraphTests {
+    func currentResult(for string: String, from location: UInt) -> UInt {
+        string.findIndexOfCurrentParagraph(from: location)
+    }
+
+    func nextResult(for string: String, from location: UInt) -> UInt {
+        string.findIndexOfNextParagraph(from: location)
     }
 }

--- a/Tests/RichTextKitTests/Extensions/String+ParagraphTests.swift
+++ b/Tests/RichTextKitTests/Extensions/String+ParagraphTests.swift
@@ -10,19 +10,18 @@ import RichTextKit
 import XCTest
 
 final class String_ParagraphTests: XCTestCase {
-    
-    let none = "foo bar baz"
-    let single = "foo\nbar baz"
-    let multi = "foo\nbar\rbaz"
 
-    func currentResult(for string: String, from location: UInt) -> UInt {
+    private let none = "foo bar baz"
+    private let single = "foo\nbar baz"
+    private let multi = "foo\nbar\rbaz"
+
+    private func currentResult(for string: String, from location: UInt) -> UInt {
         string.findIndexOfCurrentParagraph(from: location)
     }
 
-    func nextTesult(for string: String, from location: UInt) -> UInt {
+    private func nextResult(for string: String, from location: UInt) -> UInt {
         string.findIndexOfNextParagraph(from: location)
     }
-
 
     func testIndexOfCurrentParagraphIsCorrectForEmptyString() {
         XCTAssertEqual(currentResult(for: "", from: 0), 0)
@@ -49,25 +48,25 @@ final class String_ParagraphTests: XCTestCase {
 
 
     func testIndexOfNextParagraphIsCorrectForEmptyString() {
-        XCTAssertEqual(nextTesult(for: "", from: 0), 0)
-        XCTAssertEqual(nextTesult(for: "", from: 20), 0)
+        XCTAssertEqual(nextResult(for: "", from: 0), 0)
+        XCTAssertEqual(nextResult(for: "", from: 20), 0)
     }
 
     func testIndexOfNextParagraphIsCorrectForStringWithNoNextParagraph() {
-        XCTAssertEqual(nextTesult(for: none, from: 0), 0)
-        XCTAssertEqual(nextTesult(for: none, from: 10), 0)
-        XCTAssertEqual(nextTesult(for: none, from: 20), 0)
+        XCTAssertEqual(nextResult(for: none, from: 0), 0)
+        XCTAssertEqual(nextResult(for: none, from: 10), 0)
+        XCTAssertEqual(nextResult(for: none, from: 20), 0)
     }
 
     func testIndexOfNextParagraphIsCorrectForStringWithSingleNextParagraph() {
-        XCTAssertEqual(nextTesult(for: single, from: 0), 4)
-        XCTAssertEqual(nextTesult(for: single, from: 5), 4)
-        XCTAssertEqual(nextTesult(for: single, from: 10), 4)
+        XCTAssertEqual(nextResult(for: single, from: 0), 4)
+        XCTAssertEqual(nextResult(for: single, from: 5), 4)
+        XCTAssertEqual(nextResult(for: single, from: 10), 4)
     }
 
     func testIndexOfNextParagraphIsCorrectForStringWithMultipleNextParagraphs() {
-        XCTAssertEqual(nextTesult(for: multi, from: 0), 4)
-        XCTAssertEqual(nextTesult(for: multi, from: 5), 8)
-        XCTAssertEqual(nextTesult(for: multi, from: 10), 8)
+        XCTAssertEqual(nextResult(for: multi, from: 0), 4)
+        XCTAssertEqual(nextResult(for: multi, from: 5), 8)
+        XCTAssertEqual(nextResult(for: multi, from: 10), 8)
     }
 }

--- a/Tests/RichTextKitTests/Extensions/String+SubscriptTests.swift
+++ b/Tests/RichTextKitTests/Extensions/String+SubscriptTests.swift
@@ -10,15 +10,15 @@ import RichTextKit
 import XCTest
 
 final class String_SubscriptTest: XCTestCase {
-    
-    let string = "foo bar baz"
 
-    func testSharacterAtIndexIsValidWithinBounds() {
+    private let string = "foo bar baz"
+
+    func testCharacterAtIndexIsValidWithinBounds() {
         XCTAssertEqual(string.character(at: 0), "f")
         XCTAssertEqual(string.character(at: 10), "z")
     }
 
-    func testSharacterAtIndexIsNilOutsideBounds() {
+    func testCharacterAtIndexIsNilOutsideBounds() {
         XCTAssertNil(string.character(at: -1))
         XCTAssertNil(string.character(at: 11))
     }

--- a/Tests/RichTextKitTests/Fonts/StandardFontSizeProviderTests.swift
+++ b/Tests/RichTextKitTests/Fonts/StandardFontSizeProviderTests.swift
@@ -11,7 +11,6 @@ import RichTextKit
 import XCTest
 
 final class StandardFontSizeProviderTests: XCTestCase {
-    
     func testStandardRichTextFontSize() {
         XCTAssertEqual(CGFloat.standardRichTextFontSize, 16)
         CGFloat.standardRichTextFontSize = .standardRichTextFontSize

--- a/Tests/RichTextKitTests/RichTextCoordinator+SubscriptionsTests.swift
+++ b/Tests/RichTextKitTests/RichTextCoordinator+SubscriptionsTests.swift
@@ -13,13 +13,15 @@ import XCTest
 
 final class RichTextCoordinator_SubscriptionsTests: XCTestCase {
     
-    var text: NSAttributedString!
-    var textBinding: Binding<NSAttributedString>!
-    var textView: RichTextView!
-    var textContext: RichTextContext!
-    var coordinator: RichTextCoordinator!
+    private var text: NSAttributedString!
+    private var textBinding: Binding<NSAttributedString>!
+    private var textView: RichTextView!
+    private var textContext: RichTextContext!
+    private var coordinator: RichTextCoordinator!
 
     override func setUp() {
+        super.setUp()
+
         text = NSAttributedString(string: "foo bar baz")
         textBinding = Binding(get: { self.text }, set: { self.text = $0 })
         textView = RichTextView()
@@ -32,6 +34,15 @@ final class RichTextCoordinator_SubscriptionsTests: XCTestCase {
         textView.setCurrentTextAlignment(.justified)
     }
 
+    override func tearDown() {
+        text = nil
+        textBinding = nil
+        textView = nil
+        textContext = nil
+        coordinator = nil
+        
+        super.tearDown()
+    }
 
     func testTextCoordinatorIsNeededForUpdatesToTakePlace() {
         XCTAssertNotNil(coordinator)

--- a/Tests/RichTextKitTests/RichTextCoordinatorTests.swift
+++ b/Tests/RichTextKitTests/RichTextCoordinatorTests.swift
@@ -13,14 +13,15 @@ import XCTest
 @testable import RichTextKit
 
 final class RichTextCoordinatorTests: XCTestCase {
-    
-    var text: NSAttributedString!
-    var textBinding: Binding<NSAttributedString>!
-    var view: RichTextView!
-    var context: RichTextContext!
-    var coordinator: RichTextCoordinator!
+    private var text: NSAttributedString!
+    private var textBinding: Binding<NSAttributedString>!
+    private var view: RichTextView!
+    private var context: RichTextContext!
+    private var coordinator: RichTextCoordinator!
 
     override func setUp() {
+        super.setUp()
+
         text = NSAttributedString(string: "foo bar baz")
         textBinding = Binding(get: { self.text }, set: { self.text = $0 })
         view = RichTextView()
@@ -34,6 +35,15 @@ final class RichTextCoordinatorTests: XCTestCase {
         view.setCurrentTextAlignment(.justified)
     }
 
+    override func tearDown() {
+        text = nil
+        textBinding = nil
+        view = nil
+        context = nil
+        coordinator = nil
+
+        super.tearDown()
+    }
 
     func testInitializerSetsUpTextViewText() {
         XCTAssertEqual(view.richText.string, "foo bar baz")
@@ -43,15 +53,12 @@ final class RichTextCoordinatorTests: XCTestCase {
         XCTAssertTrue(view.delegate === coordinator)
     }
 
-
     func testRichTextPresenterUsesNestedTextView() {
         let range = NSRange(location: 4, length: 3)
         view.selectedRange = range
         XCTAssertEqual(coordinator.text.wrappedValue.string, "foo bar baz")
         XCTAssertEqual(coordinator.richTextContext.selectedRange, range)
     }
-
-
 
     func assertIsSyncedWithContext(macOSAlignment: RichTextAlignment = .left) {
         XCTAssertEqual(context.fontName, view.currentFontName)

--- a/Tests/RichTextKitTests/RichTextEditorTests.swift
+++ b/Tests/RichTextKitTests/RichTextEditorTests.swift
@@ -13,13 +13,15 @@ import XCTest
 
 final class RichTextEditorTests: XCTestCase {
 
-    var text: NSAttributedString!
-    var textBinding: Binding<NSAttributedString>!
-    var editor: RichTextEditor!
-    var context: RichTextContext!
-    var coordinator: RichTextCoordinator!
+    private var text: NSAttributedString!
+    private var textBinding: Binding<NSAttributedString>!
+    private var editor: RichTextEditor!
+    private var context: RichTextContext!
+    private var coordinator: RichTextCoordinator!
 
     override func setUp() {
+        super.setUp()
+
         text = NSAttributedString(string: "foo bar baz")
         textBinding = Binding(get: { self.text }, set: { self.text = $0 })
         context = RichTextContext()
@@ -27,6 +29,16 @@ final class RichTextEditorTests: XCTestCase {
             text: textBinding,
             context: context)
         coordinator = editor.makeCoordinator()
+    }
+
+    override func tearDown() {
+        text = nil
+        textBinding = nil
+        editor = nil
+        context = nil
+        coordinator = nil
+
+        super.tearDown()
     }
 
     func testRichTextPresenterUsesContextSelectedRange() {

--- a/Tests/RichTextKitTests/RichTextPresenterTests.swift
+++ b/Tests/RichTextKitTests/RichTextPresenterTests.swift
@@ -10,16 +10,23 @@ import RichTextKit
 import XCTest
 
 final class RichTextPresenterTests: XCTestCase {
-    
-    var text: NSAttributedString!
-    
+
+    private var text: NSAttributedString!
     private var presenter: MockRichTextPresenter!
 
     override func setUp() {
+        super.setUp()
+
         text = NSAttributedString(string: "foo bar baz")
         presenter = MockRichTextPresenter(text: text)
     }
 
+    override func tearDown() {
+        text = nil
+        presenter = nil
+
+        super.tearDown()
+    }
 
     func testTextRangeBeforeCursorReturnsRangeBeforeSelectionStart() {
         presenter.selectedRange = NSRange(location: 4, length: 3)

--- a/Tests/RichTextKitTests/RichTextReaderTests.swift
+++ b/Tests/RichTextKitTests/RichTextReaderTests.swift
@@ -11,8 +11,7 @@ import XCTest
 
 final class RichTextReaderTests: XCTestCase {
     
-    let string = NSAttributedString(string: "foo bar baz")
-
+    private let string = NSAttributedString(string: "foo bar baz")
 
     func testRichTextAtRangeIsValidForEmptyRangeInEmptyString() {
         let range = NSRange(location: 0, length: 0)

--- a/Tests/RichTextKitTests/RichTextViewRepresentable+AlignmentTests.swift
+++ b/Tests/RichTextKitTests/RichTextViewRepresentable+AlignmentTests.swift
@@ -20,14 +20,16 @@ import XCTest
 
 final class RichTextViewComponent_AlignmentTests: XCTestCase {
 
-    var textView: RichTextViewComponent!
+    private var textView: RichTextViewComponent!
 
-    let alignment = RichTextAlignment.right
-    let startRange = NSRange(location: 0, length: 1)
-    let selectedRange = NSRange(location: 4, length: 3)
-    let secondRowRange = NSRange(location: 14, length: 3)
+    private let alignment = RichTextAlignment.right
+    private let startRange = NSRange(location: 0, length: 1)
+    private let selectedRange = NSRange(location: 4, length: 3)
+    private let secondRowRange = NSRange(location: 14, length: 3)
 
     override func setUp() {
+        super.setUp()
+
         textView = RichTextView()
         textView.setup(
             with: NSAttributedString(string: "foo bar baz\nfoo bar baz"),
@@ -35,13 +37,19 @@ final class RichTextViewComponent_AlignmentTests: XCTestCase {
         )
     }
 
-    func assertEqualAlignment(_ attr: Any?) {
+    override func tearDown() {
+        textView = nil
+
+        super.tearDown()
+    }
+
+    private func assertEqualAlignment(_ attr: Any?) {
         let paragraphAlignment = (attr as? NSMutableParagraphStyle)?.alignment ?? .left
         let align = RichTextAlignment(paragraphAlignment)
         XCTAssertEqual(align, alignment)
     }
 
-    func assertNonEqualAlignment(_ attr: Any?) {
+    private func assertNonEqualAlignment(_ attr: Any?) {
         let paragraphAlignment = (attr as? NSMutableParagraphStyle)?.alignment ?? .left
         let align = RichTextAlignment(paragraphAlignment)
         XCTAssertNotEqual(align, alignment)

--- a/Tests/RichTextKitTests/RichTextViewRepresentable+AttributesTests.swift
+++ b/Tests/RichTextKitTests/RichTextViewRepresentable+AttributesTests.swift
@@ -42,23 +42,6 @@ final class RichTextViewComponent_AttributesTests: XCTestCase {
         super.tearDown()
     }
 
-    private func assertEqualAttribute(_ attr: Any?) {
-        XCTAssertEqual(attr as? FontRepresentable, font)
-    }
-
-    private func assertEqualAttributes(_ attr: [NSAttributedString.Key: Any]) {
-        assertEqualAttribute(attr[.font])
-    }
-
-    private func assertNonEqualAttribute(_ attr: Any?) {
-        XCTAssertNotEqual(attr as? FontRepresentable, font)
-    }
-
-    private func assertNonEqualAttributes(_ attr: [NSAttributedString.Key: Any]) {
-        assertNonEqualAttribute(attr[.font])
-    }
-
-
     func testTextAttributesIsValidForSelectedRange() {
         textView.setSelectedRange(selectedRange)
         textView.setCurrentRichTextAttribute(.font, to: font)
@@ -96,4 +79,23 @@ final class RichTextViewComponent_AttributesTests: XCTestCase {
         assertEqualAttribute(textView.typingAttributes[.font])
     }
 }
+
+private extension RichTextViewComponent_AttributesTests {
+    func assertEqualAttribute(_ attr: Any?) {
+        XCTAssertEqual(attr as? FontRepresentable, font)
+    }
+
+    func assertEqualAttributes(_ attr: [NSAttributedString.Key: Any]) {
+        assertEqualAttribute(attr[.font])
+    }
+
+    func assertNonEqualAttribute(_ attr: Any?) {
+        XCTAssertNotEqual(attr as? FontRepresentable, font)
+    }
+
+    func assertNonEqualAttributes(_ attr: [NSAttributedString.Key: Any]) {
+        assertNonEqualAttribute(attr[.font])
+    }
+}
+
 #endif

--- a/Tests/RichTextKitTests/RichTextViewRepresentable+AttributesTests.swift
+++ b/Tests/RichTextKitTests/RichTextViewRepresentable+AttributesTests.swift
@@ -20,13 +20,15 @@ import XCTest
 
 final class RichTextViewComponent_AttributesTests: XCTestCase {
 
-    var textView: RichTextViewComponent!
+    private var textView: RichTextViewComponent!
 
-    let font = FontRepresentable.systemFont(ofSize: 666)
-    let noRange = NSRange(location: 0, length: 0)
-    let selectedRange = NSRange(location: 4, length: 3)
+    private let font = FontRepresentable.systemFont(ofSize: 666)
+    private let noRange = NSRange(location: 0, length: 0)
+    private let selectedRange = NSRange(location: 4, length: 3)
 
     override func setUp() {
+        super.setUp()
+
         textView = RichTextView()
         textView.setup(
             with: NSAttributedString(string: "foo bar baz"),
@@ -34,20 +36,25 @@ final class RichTextViewComponent_AttributesTests: XCTestCase {
         )
     }
 
+    override func tearDown() {
+        textView = nil
 
-    func assertEqualAttribute(_ attr: Any?) {
+        super.tearDown()
+    }
+
+    private func assertEqualAttribute(_ attr: Any?) {
         XCTAssertEqual(attr as? FontRepresentable, font)
     }
 
-    func assertEqualAttributes(_ attr: [NSAttributedString.Key: Any]) {
+    private func assertEqualAttributes(_ attr: [NSAttributedString.Key: Any]) {
         assertEqualAttribute(attr[.font])
     }
 
-    func assertNonEqualAttribute(_ attr: Any?) {
+    private func assertNonEqualAttribute(_ attr: Any?) {
         XCTAssertNotEqual(attr as? FontRepresentable, font)
     }
 
-    func assertNonEqualAttributes(_ attr: [NSAttributedString.Key: Any]) {
+    private func assertNonEqualAttributes(_ attr: [NSAttributedString.Key: Any]) {
         assertNonEqualAttribute(attr[.font])
     }
 

--- a/Tests/RichTextKitTests/RichTextViewRepresentable+ColorTests.swift
+++ b/Tests/RichTextKitTests/RichTextViewRepresentable+ColorTests.swift
@@ -20,13 +20,15 @@ import XCTest
 
 final class RichTextViewComponent_ColorTests: XCTestCase {
 
-    var textView: RichTextViewComponent!
+    private var textView: RichTextViewComponent!
 
-    let color = ColorRepresentable.red
-    let noRange = NSRange(location: 0, length: 0)
-    let selectedRange = NSRange(location: 4, length: 3)
+    private let color = ColorRepresentable.red
+    private let noRange = NSRange(location: 0, length: 0)
+    private let selectedRange = NSRange(location: 4, length: 3)
 
     override func setUp() {
+        super.setUp()
+
         textView = RichTextView()
         textView.setup(
             with: NSAttributedString(string: "foo bar baz"),
@@ -34,14 +36,19 @@ final class RichTextViewComponent_ColorTests: XCTestCase {
         )
     }
 
-    func assertEqualColor(_ attr: Any?) {
+    override func tearDown() {
+        textView = nil
+
+        super.tearDown()
+    }
+
+    private func assertEqualColor(_ attr: Any?) {
         XCTAssertEqual(attr as? ColorRepresentable, color)
     }
 
-    func assertNonEqualColor(_ attr: Any?) {
+    private func assertNonEqualColor(_ attr: Any?) {
         XCTAssertNotEqual(attr as? ColorRepresentable, color)
     }
-
 
     func testCurrentBackgroundColorWorksForSelectedRange() {
         textView.setSelectedRange(selectedRange)

--- a/Tests/RichTextKitTests/RichTextViewRepresentable+FontSizeTests.swift
+++ b/Tests/RichTextKitTests/RichTextViewRepresentable+FontSizeTests.swift
@@ -44,23 +44,6 @@ final class RichTextViewComponent_FontSizeTests: XCTestCase {
         super.tearDown()
     }
 
-    private func assertEqualFont(_ attr: Any?) {
-        XCTAssertEqual(attr as? FontRepresentable, font)
-    }
-
-    private func assertEqualFontSize(_ attr: Any?) {
-        XCTAssertEqual((attr as? FontRepresentable)?.pointSize, size)
-    }
-
-    private func assertNonEqualFont(_ attr: Any?) {
-        XCTAssertNotEqual(attr as? FontRepresentable, font)
-    }
-
-    private func assertNonEqualFontSize(_ attr: Any?) {
-        XCTAssertNotEqual((attr as? FontRepresentable)?.pointSize, size)
-    }
-
-
     func testCurrentFontWorksForSelectedRange() {
         textView.setSelectedRange(selectedRange)
         textView.setCurrentFont(font)
@@ -102,6 +85,24 @@ final class RichTextViewComponent_FontSizeTests: XCTestCase {
         #endif
         assertNonEqualFontSize(textView.richTextAttributes(at: selectedRange)[.font])
         assertEqualFontSize(textView.typingAttributes[.font])
+    }
+}
+
+private extension RichTextViewComponent_FontSizeTests {
+    func assertEqualFont(_ attr: Any?) {
+        XCTAssertEqual(attr as? FontRepresentable, font)
+    }
+
+    func assertEqualFontSize(_ attr: Any?) {
+        XCTAssertEqual((attr as? FontRepresentable)?.pointSize, size)
+    }
+
+    func assertNonEqualFont(_ attr: Any?) {
+        XCTAssertNotEqual(attr as? FontRepresentable, font)
+    }
+
+    func assertNonEqualFontSize(_ attr: Any?) {
+        XCTAssertNotEqual((attr as? FontRepresentable)?.pointSize, size)
     }
 }
 #endif

--- a/Tests/RichTextKitTests/RichTextViewRepresentable+FontSizeTests.swift
+++ b/Tests/RichTextKitTests/RichTextViewRepresentable+FontSizeTests.swift
@@ -20,35 +20,43 @@ import XCTest
 
 final class RichTextViewComponent_FontSizeTests: XCTestCase {
 
-    var textView: RichTextViewComponent!
+    private var textView: RichTextViewComponent!
 
-    let size: CGFloat = 666
-    let font = FontRepresentable.systemFont(ofSize: 666)
-    let allRange = NSRange(location: 0, length: 11)
-    let noRange = NSRange(location: 0, length: 0)
-    let selectedRange = NSRange(location: 4, length: 3)
+    private let size: CGFloat = 666
+    private let font = FontRepresentable.systemFont(ofSize: 666)
+    private let allRange = NSRange(location: 0, length: 11)
+    private let noRange = NSRange(location: 0, length: 0)
+    private let selectedRange = NSRange(location: 4, length: 3)
 
     override func setUp() {
+        super.setUp()
+
         textView = RichTextView()
         textView.setup(
             with: NSAttributedString(string: "foo bar baz"),
             format: .rtf
         )
     }
+    
+    override func tearDown() {
+        textView = nil
 
-    func assertEqualFont(_ attr: Any?) {
+        super.tearDown()
+    }
+
+    private func assertEqualFont(_ attr: Any?) {
         XCTAssertEqual(attr as? FontRepresentable, font)
     }
 
-    func assertEqualFontSize(_ attr: Any?) {
+    private func assertEqualFontSize(_ attr: Any?) {
         XCTAssertEqual((attr as? FontRepresentable)?.pointSize, size)
     }
 
-    func assertNonEqualFont(_ attr: Any?) {
+    private func assertNonEqualFont(_ attr: Any?) {
         XCTAssertNotEqual(attr as? FontRepresentable, font)
     }
 
-    func assertNonEqualFontSize(_ attr: Any?) {
+    private func assertNonEqualFontSize(_ attr: Any?) {
         XCTAssertNotEqual((attr as? FontRepresentable)?.pointSize, size)
     }
 

--- a/Tests/RichTextKitTests/RichTextViewRepresentable+StylesTests.swift
+++ b/Tests/RichTextKitTests/RichTextViewRepresentable+StylesTests.swift
@@ -20,12 +20,14 @@ import XCTest
 
 final class RichTextViewComponent_StylesTests: XCTestCase {
 
-    var textView: RichTextViewComponent!
+    private var textView: RichTextViewComponent!
 
-    let noRange = NSRange(location: 0, length: 0)
-    let selectedRange = NSRange(location: 4, length: 3)
+    private let noRange = NSRange(location: 0, length: 0)
+    private let selectedRange = NSRange(location: 4, length: 3)
 
     override func setUp() {
+        super.setUp()
+
         textView = RichTextView()
         textView.setup(
             with: NSAttributedString(string: "foo bar baz"),
@@ -33,6 +35,11 @@ final class RichTextViewComponent_StylesTests: XCTestCase {
         )
     }
 
+    override func tearDown() {
+        textView = nil
+        
+        super.tearDown()
+    }
 
     func testIsCurrentTextBoldWorksForSelectedRange() {
         textView.setSelectedRange(selectedRange)

--- a/Tests/RichTextKitTests/RichTextViewRepresentableTests.swift
+++ b/Tests/RichTextKitTests/RichTextViewRepresentableTests.swift
@@ -12,17 +12,23 @@ import XCTest
 
 final class RichTextViewComponentTests: XCTestCase {
 
-    var view: RichTextView!
+    private var view: RichTextView!
 
     override func setUp() {
+        super.setUp()
+
         view = RichTextView()
     }
+    
+    override func tearDown() {
+        view = nil
 
+        super.tearDown()
+    }
 
     func testHighlightingStyleIsStandardByDefault() {
         XCTAssertEqual(view.highlightingStyle, .standard)
     }
-
 
     func testAttributedStringIsProperlySetAndRetrieved() {
         let string = NSAttributedString(string: "foo bar baz")
@@ -30,8 +36,7 @@ final class RichTextViewComponentTests: XCTestCase {
         XCTAssertEqual(view.attributedString.string, "foo bar baz")
     }
 
-
-    func testTextisProperlyRetrieved() {
+    func testTextIsProperlyRetrieved() {
         let string = NSAttributedString(string: "foo bar baz")
         view.attributedString = string
         XCTAssertEqual(view.richText.string, "foo bar baz")

--- a/Tests/RichTextKitTests/Styles/RichTextStyleTests.swift
+++ b/Tests/RichTextKitTests/Styles/RichTextStyleTests.swift
@@ -12,7 +12,7 @@ import XCTest
 
 final class RichTextStyleTests: XCTestCase {
 
-    func icon(for style: RichTextStyle) -> Image {
+    private func icon(for style: RichTextStyle) -> Image {
         style.icon
     }
 

--- a/Tests/RichTextKitTests/Styles/RichTextViewHighlightingStyleTests.swift
+++ b/Tests/RichTextKitTests/Styles/RichTextViewHighlightingStyleTests.swift
@@ -10,7 +10,6 @@ import RichTextKit
 import XCTest
 
 final class RichTextViewHighlightingStyleTests: XCTestCase {
-    
     func testStandardHighlightingStyleIsValid() {
         let style = RichTextHighlightingStyle.standard
         XCTAssertEqual(style.backgroundColor, .clear)


### PR DESCRIPTION
- `private` where appropriate
- `final` where appropriate
- Call `super.setUp()` - to be a good citizen
- Added [`tearDown()`](https://developer.apple.com/documentation/xctest/xctest/1500463-teardown) method to correctly deinitialize test objects
- Fixed a couple of typos