### PR TITLE
SwiftFormat init + `trailingSpace` rule

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -1,0 +1,5 @@
+# options
+--swiftversion 5.8
+
+# rules
+--rules trailingSpace

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -7,7 +7,6 @@ disabled_rules:
   - line_length
   - opening_brace
   - todo
-  - trailing_whitespace
   - type_name
   - vertical_whitespace
 

--- a/Demo/iOS/EditorScreen.swift
+++ b/Demo/iOS/EditorScreen.swift
@@ -58,7 +58,7 @@ private extension EditorScreen {
 }
 
 struct EditorScreen_Previews: PreviewProvider {
-    
+
     static var previews: some View {
         EditorScreen()
     }

--- a/Demo/macOS/EditorScreen.swift
+++ b/Demo/macOS/EditorScreen.swift
@@ -59,7 +59,7 @@ private extension EditorScreen {
 }
 
 struct EditorScreen_Previews: PreviewProvider {
-    
+
     static var previews: some View {
         EditorScreen()
     }

--- a/Sources/RichTextKit/Actions/RichTextAction.swift
+++ b/Sources/RichTextKit/Actions/RichTextAction.swift
@@ -19,34 +19,34 @@ public enum RichTextAction: Identifiable, Equatable {
 
     /// Dismiss any presented software keyboard.
     case dismissKeyboard
-    
+
     /// A print command.
     case print
 
     /// Redo the latest undone change.
     case redoLatestChange
-    
+
     /// Set the text alignment.
     case setAlignment(_ alignment: RichTextAlignment)
-    
+
     /// Step the font size.
     case stepFontSize(points: Int)
-    
+
     /// Step the indent level.
     case stepIndent(points: CGFloat)
-    
+
     /// Step the superscript level.
     case stepSuperscript(steps: Int)
-    
+
     /// Toggle a certain style.
     case toggleStyle(_ style: RichTextStyle)
-    
+
     /// Undo the latest change.
     case undoLatestChange
 }
 
 public extension RichTextAction {
-    
+
     /// The action's unique identifier.
     var id: String { title }
 
@@ -68,7 +68,7 @@ public extension RichTextAction {
         case .undoLatestChange: return .richTextActionUndo
         }
     }
-    
+
     /// The localized title to use in the main menu.
     var menuTitle: String {
         switch self {
@@ -77,7 +77,7 @@ public extension RichTextAction {
         default: return title
         }
     }
-    
+
     /// The localized title.
     var title: String {
         switch self {
@@ -102,81 +102,81 @@ public extension RichTextAction {
 // MARK: - Aliases
 
 public extension RichTextAction {
-    
+
     /// A name alias for `.stepFontSize`.
     static var increaseFontSize: RichTextAction {
         increaseFontSize()
     }
-    
+
     /// A name alias for `.stepFontSize`.
     static func increaseFontSize(
         points: UInt = 1
     ) -> RichTextAction {
         stepFontSize(points: Int(points))
     }
-    
+
     /// A name alias for `.stepFontSize`.
     static var decreaseFontSize: RichTextAction {
         decreaseFontSize()
     }
-    
+
     /// A name alias for `.stepFontSize(points: -1)`.
     static func decreaseFontSize(
         points: UInt = 1
     ) -> RichTextAction {
         stepFontSize(points: -Int(points))
     }
-    
-    
+
+
     /// A name alias for `.stepIndent`.
     static var increaseIndent: RichTextAction {
         increaseIndent()
     }
-    
+
     /// A name alias for `.stepIndent`.
     static func increaseIndent(
         points: UInt = .defaultRichTextIntentStepSize
     ) -> RichTextAction {
         stepIndent(points: CGFloat(points))
     }
-    
+
     /// A name alias for `.stepIndent`.
     static var decreaseIndent: RichTextAction {
         decreaseIndent()
     }
-    
+
     /// A name alias for `.stepIndent(points: -1)`.
     static func decreaseIndent(
         points: UInt = .defaultRichTextIntentStepSize
     ) -> RichTextAction {
         stepIndent(points: -CGFloat(points))
     }
-    
-    
+
+
     /// A name alias for `.stepFontSize`.
     static var increaseSuperscript: RichTextAction {
         increaseFontSize()
     }
-    
+
     /// A name alias for `.stepSuperscript`.
     static func increaseSuperscript(
         steps: UInt = 1
     ) -> RichTextAction {
         stepSuperscript(steps: Int(steps))
     }
-    
+
     /// A name alias for `.stepSuperscript`.
     static var decreaseSuperscript: RichTextAction {
         decreaseSuperscript()
     }
-    
+
     /// A name alias for `.stepSuperscript(steps: -1)`.
     static func decreaseSuperscript(
         steps: UInt = 1
     ) -> RichTextAction {
         stepSuperscript(steps: -Int(steps))
     }
-    
+
 
     /// A name alias for `.redoLatestChange`.
     static var redo: RichTextAction { .redoLatestChange }

--- a/Sources/RichTextKit/Actions/RichTextActionButton.swift
+++ b/Sources/RichTextKit/Actions/RichTextActionButton.swift
@@ -10,15 +10,15 @@ import SwiftUI
 
 /**
  This button can be used to trigger a ``RichTextAction``.
- 
+
  This renders a plain `Button`, which means that you can use
  and configure it as normal.
  */
 public struct RichTextActionButton: View {
-    
+
     /**
      Create a rich text action button.
-     
+
      - Parameters:
        - action: The action to trigger.
        - context: The context to affect.
@@ -33,13 +33,13 @@ public struct RichTextActionButton: View {
         self._context = ObservedObject(wrappedValue: context)
         self.fillVertically = fillVertically
     }
-    
+
     private let action: RichTextAction
     private let fillVertically: Bool
-    
+
     @ObservedObject
     private var context: RichTextContext
-    
+
     public var body: some View {
         Button(action: triggerAction) {
             action.icon
@@ -53,19 +53,19 @@ public struct RichTextActionButton: View {
 }
 
 private extension RichTextActionButton {
-    
+
     func triggerAction() {
         context.handle(action)
     }
 }
 
 struct RichTextActionButton_Previews: PreviewProvider {
-    
+
     struct Preview: View {
-        
+
         @StateObject
         private var context = RichTextContext()
-        
+
         var body: some View {
             HStack {
                 RichTextActionButton(
@@ -109,7 +109,7 @@ struct RichTextActionButton_Previews: PreviewProvider {
             .buttonStyle(.bordered)
         }
     }
-    
+
     static var previews: some View {
         Preview()
     }

--- a/Sources/RichTextKit/Alignment/RichTextAlignment.swift
+++ b/Sources/RichTextKit/Alignment/RichTextAlignment.swift
@@ -10,7 +10,7 @@ import SwiftUI
 
 /**
  This enum defines supported rich text alignments.
- 
+
  The enum makes the alignment type identifiable and diffable.
  */
 public enum RichTextAlignment: String, CaseIterable, Codable, Equatable, Identifiable {
@@ -36,7 +36,7 @@ public enum RichTextAlignment: String, CaseIterable, Codable, Equatable, Identif
 
     /// Center text alignment.
     case center
-    
+
     /// Justified text alignment.
     case justified
 
@@ -48,10 +48,10 @@ public extension RichTextAlignment {
 
     /// The unique ID of the alignment.
     var id: String { rawValue }
-    
+
     /// The standard icon to use for the alignment.
     var icon: Image { nativeAlignment.icon }
-    
+
     /// The standard title to use for the alignment.
     var title: String { nativeAlignment.title }
 
@@ -67,7 +67,7 @@ public extension RichTextAlignment {
 }
 
 public extension NSTextAlignment {
-    
+
     /// The standard icon to use for the alignment.
     var icon: Image {
         switch self {
@@ -78,12 +78,12 @@ public extension NSTextAlignment {
         default: return .richTextAlignmentLeft
         }
     }
-    
+
     /// The standard title to use for the alignment.
     var title: String {
         titleCase.text
     }
-    
+
     /// The standard title to use for the alignment.
     var titleCase: RTKL10n {
         switch self {

--- a/Sources/RichTextKit/Alignment/RichTextAlignmentPicker.swift
+++ b/Sources/RichTextKit/Alignment/RichTextAlignmentPicker.swift
@@ -35,7 +35,7 @@ public struct RichTextAlignmentPicker: View {
 
     @Binding
     private var selection: RichTextAlignment
-    
+
     public var body: some View {
         Picker("", selection: $selection) {
             ForEach(RichTextAlignment.allCases) {

--- a/Sources/RichTextKit/Attributes/RichTextAttributeReader+Colors.swift
+++ b/Sources/RichTextKit/Attributes/RichTextAttributeReader+Colors.swift
@@ -16,28 +16,28 @@ public extension RichTextAttributeReader {
     ) -> ColorRepresentable? {
         richTextAttribute(.backgroundColor, at: range)
     }
-    
+
     /// Get the foreground color at a certain range.
     func richTextForegroundColor(
         at range: NSRange
     ) -> ColorRepresentable? {
         richTextAttribute(.foregroundColor, at: range)
     }
-    
+
     /// Get the strikethrough color at a certain range.
     func richTextStrikethroughColor(
         at range: NSRange
     ) -> ColorRepresentable? {
         richTextAttribute(.strikethroughColor, at: range)
     }
-    
+
     /// Get the stroke color at a certain range.
     func richTextStrokeColor(
         at range: NSRange
     ) -> ColorRepresentable? {
         richTextAttribute(.strokeColor, at: range)
     }
-    
+
     /// Get the underline color at a certain range.
     func richTextUnderlineColor(
         at range: NSRange

--- a/Sources/RichTextKit/Attributes/RichTextAttributeReader.swift
+++ b/Sources/RichTextKit/Attributes/RichTextAttributeReader.swift
@@ -28,7 +28,7 @@ public extension RichTextAttributeReader {
     ) -> Value? {
         richTextAttributes(at: range)[attribute] as? Value
     }
-    
+
     /// Get all rich text attributes at a certain range.
     func richTextAttributes(
         at range: NSRange

--- a/Sources/RichTextKit/Attributes/RichTextAttributeWriter+Colors.swift
+++ b/Sources/RichTextKit/Attributes/RichTextAttributeWriter+Colors.swift
@@ -17,7 +17,7 @@ public extension RichTextAttributeWriter {
     ) {
         setRichTextAttribute(.backgroundColor, to: color, at: range)
     }
-    
+
     /// Set the foreground color at a certain range.
     func setRichTextForegroundColor(
         _ color: ColorRepresentable,
@@ -25,7 +25,7 @@ public extension RichTextAttributeWriter {
     ) {
         setRichTextAttribute(.foregroundColor, to: color, at: range)
     }
-    
+
     /// Set the strikethrough color at a certain range.
     func setRichTextStrikethroughColor(
         _ color: ColorRepresentable,
@@ -33,7 +33,7 @@ public extension RichTextAttributeWriter {
     ) {
         setRichTextAttribute(.strikethroughColor, to: color, at: range)
     }
-    
+
     /// Set the stroke color at a certain range.
     func setRichTextStrokeColor(
         _ color: ColorRepresentable,
@@ -41,7 +41,7 @@ public extension RichTextAttributeWriter {
     ) {
         setRichTextAttribute(.strokeColor, to: color, at: range)
     }
-    
+
     /// Set the underline color at a certain range.
     func setRichTextUnderlineColor(
         _ color: ColorRepresentable,
@@ -49,5 +49,5 @@ public extension RichTextAttributeWriter {
     ) {
         setRichTextAttribute(.underlineColor, to: color, at: range)
     }
-    
+
 }

--- a/Sources/RichTextKit/Attributes/RichTextAttributeWriter+Font.swift
+++ b/Sources/RichTextKit/Attributes/RichTextAttributeWriter+Font.swift
@@ -17,7 +17,7 @@ public extension RichTextAttributeWriter {
     ) {
         setRichTextAttribute(.font, to: font, at: range)
     }
-    
+
     /**
      Set the font name at a certain range.
 

--- a/Sources/RichTextKit/Attributes/RichTextAttributeWriter+Indent.swift
+++ b/Sources/RichTextKit/Attributes/RichTextAttributeWriter+Indent.swift
@@ -20,7 +20,7 @@ public extension RichTextAttributeWriter {
 
     /**
      Set the text indent at the provided range.
-     
+
      Unlike some other attributes, this value applies to the
      entire paragraph, not just the selected range.
      */
@@ -52,7 +52,7 @@ public extension RichTextAttributeWriter {
         let index = text.findIndexOfCurrentParagraph(from: location)
         return stepRichTextIndent(points: points, atIndex: index)
     }
-    
+
     /// Step the text indent at a certain index.
     func stepRichTextIndent(
         points: CGFloat,
@@ -63,17 +63,17 @@ public extension RichTextAttributeWriter {
         let safeRange = safeRange(for: range, isAttributeOperation: true)
         var attributes = text.attributes(at: safeRange.location, effectiveRange: nil)
         let style = attributes[.paragraphStyle] as? NSMutableParagraphStyle ?? NSMutableParagraphStyle()
-        
+
         let newIndent = max(style.headIndent + points, 0)
         style.firstLineHeadIndent = newIndent
         style.headIndent = newIndent
-        
+
         attributes[.paragraphStyle] = style
         text.beginEditing()
         text.setAttributes(attributes, range: safeRange)
         text.fixAttributes(in: safeRange)
         text.endEditing()
-        
+
         return attributes
     }
 

--- a/Sources/RichTextKit/Colors/RichTextColor.swift
+++ b/Sources/RichTextKit/Colors/RichTextColor.swift
@@ -10,14 +10,14 @@ import SwiftUI
 
 /**
  This enum defines supported rich text color types.
- 
+
  The enum makes the colors identifiable and diffable.
  */
 public enum RichTextColor: String, CaseIterable, Codable, Equatable, Identifiable {
 
     /// Foreground color.
     case foreground
-    
+
     /// Background color.
     case background
 
@@ -32,7 +32,7 @@ public extension RichTextColor {
 
     /// The unique ID of the alignment.
     var id: String { rawValue }
-    
+
     /// The standard icon to use for the alignment.
     var icon: Image {
         switch self {

--- a/Sources/RichTextKit/Colors/RichTextColorPicker.swift
+++ b/Sources/RichTextKit/Colors/RichTextColorPicker.swift
@@ -10,7 +10,7 @@ import SwiftUI
 
 /**
  This picker can be used to select a color.
- 
+
  This picker renders an icon next to the color picker and an
  optional list of horizontally scrolling quick colors.
 
@@ -18,7 +18,7 @@ import SwiftUI
  custom set of colors, for instance `.quickPickerColors`.
  */
 public struct RichTextColorPicker: View {
-    
+
     /**
      Create a rich text color picker that binds to a color.
 
@@ -40,7 +40,7 @@ public struct RichTextColorPicker: View {
     private let icon: Image?
     private let value: Binding<Color>
     private let quickColors: [Color]
-    
+
     private let spacing = 10.0
 
     @Environment(\.colorScheme)
@@ -60,14 +60,14 @@ public struct RichTextColorPicker: View {
 }
 
 private extension RichTextColorPicker {
-    
+
     var hasColors: Bool {
         !quickColors.isEmpty
     }
 }
 
 public extension Color {
-    
+
     /// Get a curated list of quick color picker colors.
     static var quickPickerColors: [Self] {
         [
@@ -80,7 +80,7 @@ public extension Color {
 }
 
 public extension Collection where Element == Color {
-    
+
     /// Get a curated list of quick color picker colors.
     static var quickPickerColors: [Element] {
         Element.quickPickerColors
@@ -135,24 +135,24 @@ private extension RichTextColorPicker {
 }
 
 private extension ColorScheme {
-    
+
     func textColor(for color: Color) -> Color {
         let usePrimary = usePrimaryColor(for: color)
         return usePrimary ? .primary : color
     }
-    
+
     func usePrimaryColor(for color: Color) -> Bool {
         (self == .dark && color == .white) || (self == .light && color == .black)
     }
 }
 
 private struct ColorButtonStyle: ButtonStyle {
-    
+
     let isSelected: Bool
-    
+
     @Environment(\.isFocused)
     var isFocused: Bool
-    
+
     func makeBody(configuration: Configuration) -> some View {
         let focusSize: Double = isFocused ? 25 : 20
         let size: Double = isSelected ? 30 : focusSize

--- a/Sources/RichTextKit/Commands/RichTextCommandButton.swift
+++ b/Sources/RichTextKit/Commands/RichTextCommandButton.swift
@@ -10,18 +10,18 @@ import SwiftUI
 
 /**
  This button can be used to trigger a ``RichTextAction``.
- 
+
  This button gets the ``RichTextContext`` as a focused value.
- 
+
  The button renders a plain `Button` with a title and action,
  that is meant to be used in a `Commands` group and rendered
  in the main menu.
  */
 public struct RichTextCommandButton: View {
-    
+
     /**
      Create a rich text command button.
-     
+
      - Parameters:
        - action: The action to trigger.
      */
@@ -30,12 +30,12 @@ public struct RichTextCommandButton: View {
     ) {
         self.action = action
     }
-    
+
     private let action: RichTextAction
-    
+
     @FocusedValue(\.richTextContext)
     private var context: RichTextContext?
-    
+
     public var body: some View {
         Button(action.menuTitle) {
             context?.handle(action)
@@ -44,17 +44,17 @@ public struct RichTextCommandButton: View {
         .keyboardShortcut(for: action)
         .accessibilityLabel(action.title)
     }
-    
+
     private var canHandle: Bool {
         context?.canHandle(action) ?? false
     }
 }
 
 public struct RichTextCommandButtonGroup: View {
-    
+
     /**
      Create a rich text command button group.
-     
+
      - Parameters:
        - actions: The actions to trigger.
      */
@@ -63,9 +63,9 @@ public struct RichTextCommandButtonGroup: View {
     ) {
         self.actions = actions
     }
-    
+
     private let actions: [RichTextAction]
-    
+
     public var body: some View {
         ForEach(actions) {
             RichTextCommandButton(action: $0)

--- a/Sources/RichTextKit/Commands/RichTextCommandsFontSizeOptionsGroup.swift
+++ b/Sources/RichTextKit/Commands/RichTextCommandsFontSizeOptionsGroup.swift
@@ -12,12 +12,12 @@ import SwiftUI
  This view defines `Commands` content for font size options.
  */
 public struct RichTextCommandsFontSizeOptionsGroup: View {
-    
+
     public init() {}
-    
+
     @FocusedValue(\.richTextContext)
     private var context: RichTextContext?
-    
+
     public var body: some View {
         RichTextCommandButtonGroup(
             actions: [

--- a/Sources/RichTextKit/Commands/RichTextCommandsIndentOptionsGroup.swift
+++ b/Sources/RichTextKit/Commands/RichTextCommandsIndentOptionsGroup.swift
@@ -15,7 +15,7 @@ public struct RichTextCommandsIndentOptionsGroup: View {
 
     @FocusedValue(\.richTextContext)
     private var context: RichTextContext?
-    
+
     public var body: some View {
         RichTextCommandButtonGroup(
             actions: [

--- a/Sources/RichTextKit/Commands/RichTextShareCommandMenu.swift
+++ b/Sources/RichTextKit/Commands/RichTextShareCommandMenu.swift
@@ -19,12 +19,12 @@ import SwiftUI
  Regarding sharing, the macOS exclusive `nsSharing` commands
  require you to return a share url, after which the commands
  take care of the sharing.
- 
+
  Note that a pdf action menu will only be included if it has
  a corresponding action. You must also add `isEnabled: false`
  to disable the menu, since you can't add `.disabled` to the
  command menu.
- 
+
  Setting an action to `nil` removes the option from the menu.
  */
 public struct RichTextShareCommandMenu: Commands {

--- a/Sources/RichTextKit/Component/RichTextViewComponent+Color.swift
+++ b/Sources/RichTextKit/Component/RichTextViewComponent+Color.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 public extension RichTextViewComponent {
-    
+
     /// Get the current value of a certain color.
     func currentColor(
         _ color: RichTextColor
@@ -25,7 +25,7 @@ public extension RichTextViewComponent {
             return currentRichTextAttribute(.strokeColor)
         }
     }
-    
+
     /// Set the current value of a certain color.
     func setCurrentColor(
         _ color: RichTextColor,

--- a/Sources/RichTextKit/Component/RichTextViewComponent.swift
+++ b/Sources/RichTextKit/Component/RichTextViewComponent.swift
@@ -28,7 +28,7 @@ public protocol RichTextViewComponent: AnyObject,
     RichTextImageAttachmentManager,
     RichTextPdfDataReader
 {
-        
+
     /// The text view's frame.
     var frame: CGRect { get }
 
@@ -93,7 +93,7 @@ public extension RichTextViewComponent {
     func alert(title: String, message: String) {
         alert(title: title, message: message, buttonTitle: "OK")
     }
-    
+
     /// Delete all characters in a certain range.
     func deleteCharacters(in range: NSRange) {
         mutableAttributedString?.deleteCharacters(in: range)

--- a/Sources/RichTextKit/Context/RichTextContext+Actions.swift
+++ b/Sources/RichTextKit/Context/RichTextContext+Actions.swift
@@ -9,7 +9,7 @@
 import SwiftUI
 
 public extension RichTextContext {
-    
+
     /// Handle a certain rich text action.
     func handle(_ action: RichTextAction) {
         switch action {

--- a/Sources/RichTextKit/Context/RichTextContext+Colors.swift
+++ b/Sources/RichTextKit/Context/RichTextContext+Colors.swift
@@ -9,7 +9,7 @@
 import SwiftUI
 
 public extension RichTextContext {
-    
+
     /// Get a binding for a certain color.
     func binding(for val: RichTextColor) -> Binding<Color> {
         Binding(
@@ -17,7 +17,7 @@ public extension RichTextContext {
             set: { self.setColor(ColorRepresentable($0), for: val) }
         )
     }
-    
+
     /// Get the value for a certain color.
     func color(for val: RichTextColor) -> ColorRepresentable? {
         switch val {
@@ -27,7 +27,7 @@ public extension RichTextContext {
         case .stroke: return strokeColor
         }
     }
-    
+
     /// Set the value for a certain color.
     func setColor(
         _ color: ColorRepresentable,

--- a/Sources/RichTextKit/Context/RichTextContext+Styles.swift
+++ b/Sources/RichTextKit/Context/RichTextContext+Styles.swift
@@ -9,7 +9,7 @@
 import SwiftUI
 
 public extension RichTextContext {
-    
+
     /// Get a binding for a certain style.
     func binding(for style: RichTextStyle) -> Binding<Bool> {
         Binding(
@@ -17,7 +17,7 @@ public extension RichTextContext {
             set: { self.set(style, to: $0) }
         )
     }
-    
+
     /// Check whether or not the context has a certain style.
     func hasStyle(_ style: RichTextStyle) -> Bool {
         switch style {
@@ -27,7 +27,7 @@ public extension RichTextContext {
         case .strikethrough: return isStrikethrough
         }
     }
-    
+
     /// Set whether or not the context has a certain style.
     func set(
         _ style: RichTextStyle,
@@ -40,7 +40,7 @@ public extension RichTextContext {
         case .strikethrough: isStrikethrough = val
         }
     }
-    
+
     /// Toggle a certain style for the context.
     func toggle(_ style: RichTextStyle) {
         set(style, to: !hasStyle(style))

--- a/Sources/RichTextKit/Context/RichTextContext.swift
+++ b/Sources/RichTextKit/Context/RichTextContext.swift
@@ -21,18 +21,18 @@ public class RichTextContext: ObservableObject {
 
     /// Create a new rich text context instance.
     public init() {}
-    
-    
+
+
     // MARK: - Not yet observable properties
-    
+
     /**
      The currently attributed string, if any.
-     
+
      Note that the property is read-only and not `@Published`
      to avoid redrawing the editor when it changes, which is
      done constantly as the user types. We should find a way
      to observe this property without this happening.
-     
+
      The best way to observe this property is to use the raw
      `text` binding that you pass into your text editor. The
      editor will however not redraw if you change this value
@@ -41,10 +41,10 @@ public class RichTextContext: ObservableObject {
      Until then, use `setAttributedString(to:)` to change it.
      */
     public internal(set) var attributedString = NSAttributedString()
-    
+
     /**
      The currently selected range, if any.
-     
+
      Note that the property is read-only and not `@Published`
      to avoid redrawing the editor when it changes, which is
      done constantly as the user types. We should find a way
@@ -56,7 +56,7 @@ public class RichTextContext: ObservableObject {
 
 
     // MARK: - Observable properies
-    
+
     /// The current background color, if any.
     @Published
     public var backgroundColor: ColorRepresentable?
@@ -72,11 +72,11 @@ public class RichTextContext: ObservableObject {
     /// Whether or not the latest change can be undone.
     @Published
     public var canUndoLatestChange = false
-    
+
     /// Whether or not the indent level can be decreased.
     @Published
     public var canDecreaseIndent = true
-    
+
     /// Whether or not the indent level can be increased.
     @Published
     public var canIncreaseIndent = true
@@ -120,22 +120,22 @@ public class RichTextContext: ObservableObject {
     /// Whether or not the current text is underlined.
     @Published
     public var isUnderlined = false
-    
+
     /// The current strikethrough color, if any.
     @Published
     public var strikethroughColor: ColorRepresentable?
-    
+
     /// The current stroke color, if any.
     @Published
     public var strokeColor: ColorRepresentable?
-    
+
     /// The current text alignment, if any.
     @Published
     public var textAlignment: RichTextAlignment = .left
-    
-    
+
+
     // MARK: - Internal trigger properties
-    
+
     /// Set this property to trigger a certain action.
     @Published
     var triggerAction: RichTextAction?
@@ -155,7 +155,7 @@ public class RichTextContext: ObservableObject {
     /// Set this property to trigger a string update.
     @Published
     var shouldSetAttributedString: NSAttributedString?
-    
+
     /// Set this property to trigger a range change.
     @Published
     var shouldSelectRange = NSRange()

--- a/Sources/RichTextKit/Coordinator/RichTextCoordinator+Subscriptions.swift
+++ b/Sources/RichTextKit/Coordinator/RichTextCoordinator+Subscriptions.swift
@@ -37,7 +37,7 @@ extension RichTextCoordinator {
 }
 
 private extension RichTextCoordinator {
-    
+
     func handle(_ action: RichTextAction?) {
         guard let action else { return }
         switch action {
@@ -60,7 +60,7 @@ private extension RichTextCoordinator {
             syncContextWithTextView()
         }
     }
-    
+
     func subscribeToTriggerAction() {
         richTextContext.$triggerAction
             .sink(
@@ -70,7 +70,7 @@ private extension RichTextCoordinator {
                 })
             .store(in: &cancellables)
     }
-    
+
 
     func subscribeToAlignment() {
         richTextContext.$textAlignment
@@ -233,7 +233,7 @@ private extension RichTextCoordinator {
                 })
             .store(in: &cancellables)
     }
-    
+
     func subscribeToShouldSelectRange() {
         richTextContext.$shouldSelectRange
             .sink(
@@ -243,7 +243,7 @@ private extension RichTextCoordinator {
                 })
             .store(in: &cancellables)
     }
-    
+
     func subscribeToStrokeColor() {
         richTextContext.$strokeColor
             .sink(
@@ -254,7 +254,7 @@ private extension RichTextCoordinator {
                 })
             .store(in: &cancellables)
     }
-    
+
     func subscribeToStrikethroughColor() {
         richTextContext.$strikethroughColor
             .sink(

--- a/Sources/RichTextKit/Coordinator/RichTextCoordinator.swift
+++ b/Sources/RichTextKit/Coordinator/RichTextCoordinator.swift
@@ -189,12 +189,12 @@ extension RichTextCoordinator {
         if richTextContext.attributedString != string {
             richTextContext.attributedString = string
         }
-        
+
         let range = textView.selectedRange
         if richTextContext.selectedRange != range {
             richTextContext.selectedRange = range
         }
-        
+
         RichTextColor.allCases.forEach {
             if let color = textView.currentColor($0) {
                 richTextContext.setColor(color, for: $0)
@@ -205,17 +205,17 @@ extension RichTextCoordinator {
         if richTextContext.foregroundColor != foreground {
             richTextContext.foregroundColor = foreground
         }
-        
+
         let background = textView.currentColor(.background)
         if richTextContext.backgroundColor != background {
             richTextContext.backgroundColor = background
         }
-        
+
         let stroke = textView.currentColor(.stroke)
         if richTextContext.strokeColor != stroke {
             richTextContext.strokeColor = stroke
         }
-        
+
         let strike = textView.currentColor(.strikethrough)
         if richTextContext.strikethroughColor != strike {
             richTextContext.strikethroughColor = strike

--- a/Sources/RichTextKit/Data/RichTextDataFormat.swift
+++ b/Sources/RichTextKit/Data/RichTextDataFormat.swift
@@ -11,7 +11,7 @@ import UniformTypeIdentifiers
 
 /**
  This enum specifies rich text data formats.
- 
+
  Different formats handle rich text in different ways.
 
  For instance, ``rtf`` supports rich text attributes, styles,
@@ -30,10 +30,10 @@ import UniformTypeIdentifiers
  open with the app. Have a look at the demo app for examples.
  */
 public enum RichTextDataFormat: Equatable, Identifiable {
-    
+
     /// Archived data that's persisted with a keyed archiver.
     case archivedData
-    
+
     /// Plain data is persisted as plain text.
     case plainText
 
@@ -62,7 +62,7 @@ public extension RichTextDataFormat {
     static var libraryFormats: [RichTextDataFormat] {
         [.archivedData, .plainText, .rtf]
     }
-    
+
     /// The format's unique identifier.
     var id: String {
         switch self {
@@ -72,7 +72,7 @@ public extension RichTextDataFormat {
         case .vendorArchivedData(let id, _, _, _): return id
         }
     }
-    
+
     /// The formats that a format can be converted to.
     var convertibleFormats: [RichTextDataFormat] {
         switch self {
@@ -100,7 +100,7 @@ public extension RichTextDataFormat {
         case .vendorArchivedData: return true
         }
     }
-    
+
     /// The format's standard file extension.
     var standardFileExtension: String {
         switch self {
@@ -110,7 +110,7 @@ public extension RichTextDataFormat {
         case .vendorArchivedData(_, let ext, _, _): return ext
         }
     }
-    
+
     /// Whether or not the format supports images.
     var supportsImages: Bool {
         switch self {
@@ -120,7 +120,7 @@ public extension RichTextDataFormat {
         case .vendorArchivedData: return true
         }
     }
-    
+
     /// The format's uniform type.
     var uniformType: UTType {
         switch self {

--- a/Sources/RichTextKit/Data/UTType+RichText.swift
+++ b/Sources/RichTextKit/Data/UTType+RichText.swift
@@ -9,7 +9,7 @@
 import UniformTypeIdentifiers
 
 public extension UTType {
-    
+
     /// Uniform rich text types that RichTextKit supports.
     static let richTextTypes: [UTType] = [
         .archivedData,
@@ -18,7 +18,7 @@ public extension UTType {
         .plainText,
         .data
     ]
-    
+
     /// The uniform type for ``RichTextFormat/archivedData``.
     static let archivedData = UTType(
         exportedAs: "com.richtextkit.archiveddata")

--- a/Sources/RichTextKit/Export/RichTextExportService.swift
+++ b/Sources/RichTextKit/Export/RichTextExportService.swift
@@ -17,11 +17,11 @@ import Foundation
  a ``RichTextShareService`` instead.
  */
 public protocol RichTextExportService: AnyObject {
-    
+
     /**
      Generate an export file with a certain name and content,
      that uses a certain rich text data format.
-     
+
      - Parameters:
        - fileName: The preferred file name.
        - content: The rich text content to export.
@@ -31,11 +31,11 @@ public protocol RichTextExportService: AnyObject {
         withName fileName: String,
         content: NSAttributedString,
         format: RichTextDataFormat) throws -> URL
-    
+
     /**
      Generate a PDF export file with a certain name and rich
      text content.
-     
+
      - Parameters:
        - fileName: The preferred file name.
        - content: The rich text content to export.

--- a/Sources/RichTextKit/Export/StandardRichTextExportService.swift
+++ b/Sources/RichTextKit/Export/StandardRichTextExportService.swift
@@ -17,10 +17,10 @@ import Foundation
  another data format.
  */
 public class StandardRichTextExportService: RichTextExportService {
-    
+
     /**
      Create a standard rich text export service.
-     
+
      - Parameters:
        - urlResolver: The type to use to resolve file urls, by default `FileManager.default`.
        - directory: The directory to save the file in, by default `.documentDirectory`.
@@ -32,10 +32,10 @@ public class StandardRichTextExportService: RichTextExportService {
         self.urlResolver = urlResolver
         self.directory = directory
     }
-    
+
     private let urlResolver: RichTextExportUrlResolver
     private let directory: FileManager.SearchPathDirectory
-    
+
     /**
      Generate a file with a certain name, content and format.
 
@@ -46,7 +46,7 @@ public class StandardRichTextExportService: RichTextExportService {
      To achieve this, we'll use the `uniqueFileUrl` function
      of the url resolver, which by default will add a suffix
      until the file name no longer exists.
-     
+
      - Parameters:
        - fileName: The preferred name of the exported name.
        - content: The rich text content to export.
@@ -65,7 +65,7 @@ public class StandardRichTextExportService: RichTextExportService {
         try data.write(to: fileUrl)
         return fileUrl
     }
-    
+
     /**
      Generate a PDF file with a certain name and content.
 
@@ -76,7 +76,7 @@ public class StandardRichTextExportService: RichTextExportService {
      To achieve this, we'll use the `uniqueFileUrl` function
      of the url resolver, which by default will add a suffix
      until the file name no longer exists.
-     
+
      - Parameters:
        - fileName: The preferred file name.
        - content: The rich text content to export.

--- a/Sources/RichTextKit/Extensions/CGFloat+Indent.swift
+++ b/Sources/RichTextKit/Extensions/CGFloat+Indent.swift
@@ -9,11 +9,11 @@
 import Foundation
 
 public extension CGFloat {
-    
+
     static var defaultRichTextIntentStepSize: CGFloat = 30.0
 }
 
 public extension UInt {
-    
+
     static var defaultRichTextIntentStepSize: UInt = 30
 }

--- a/Sources/RichTextKit/Extensions/NSAttributedString+Empty.swift
+++ b/Sources/RichTextKit/Extensions/NSAttributedString+Empty.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 public extension NSAttributedString {
- 
+
     /// Create an empty attributed string.
     static var empty: NSAttributedString {
         NSAttributedString(string: "")

--- a/Sources/RichTextKit/Extensions/String+Characters.swift
+++ b/Sources/RichTextKit/Extensions/String+Characters.swift
@@ -18,13 +18,13 @@ public extension String.Element {
 
     /// Get the string element for a `\t` tab.
     static var tab: String.Element { "\t" }
-    
+
     /// Get the string element for a ` ` space.
     static var space: String.Element { " " }
 }
 
 public extension String {
-    
+
     /// Get the string for a `\r` carriage return.
     static let carriageReturn = String(.carriageReturn)
 
@@ -33,7 +33,7 @@ public extension String {
 
     /// Get the string for a `\t` tab.
     static let tab = String(.tab)
-    
+
     /// Get the string for a ` ` space.
     static let space = String(.space)
 }

--- a/Sources/RichTextKit/Extensions/String+Paragraph.swift
+++ b/Sources/RichTextKit/Extensions/String+Paragraph.swift
@@ -9,11 +9,11 @@
 import Foundation
 
 public extension String {
-    
+
     /**
      Backs to find the index of the first new line paragraph
      before the provided location, if any.
-     
+
      A new paragraph is considered to start at the character
      after the newline char, not the newline itself.
      */
@@ -29,12 +29,12 @@ public extension String {
         } while true
         return max(index, 0)
     }
-    
+
     /**
      Looks forward to find the next new line paragraph after
      the provided location, if any. If no next paragraph can
      be found, the current is returned.
-     
+
      A new paragraph is considered to start at the character
      after the newline char, not the newline itself.
      */
@@ -49,16 +49,16 @@ public extension String {
         let found = index < count
         return found ? index : findIndexOfCurrentParagraph(from: location)
     }
-    
+
     /**
      Looks forward to find the next new line paragraph after
      the provided location, if any. If no next paragraph can
      be found, the last index of the paragraph is returned.
-     
+
      A new paragraph is considered to start at the character
      after the newline char, not the newline itself.
      */
-    
+
     func findIndexOfNextParagraphOrEndofCurrent(from location: UInt) -> UInt {
         var index = location
         repeat {
@@ -70,10 +70,10 @@ public extension String {
         let found = index < count
         return UInt(found ? index : UInt(count))
     }
-    
+
     /**
      Returns the length of the paragraph found at the location provided..
-     
+
      A new paragraph is considered to start at the character
      after the newline char, not the newline itself.
      */
@@ -83,10 +83,10 @@ public extension String {
         let endIndex = findIndexOfNextParagraphOrEndofCurrent(from: location)
         return Int(endIndex)-Int(startIndex)
     }
-    
+
     /**
      Returns the index of the word at the location provided..
-     
+
      A word is considered to be a length of text between two
      breaking characters or space characters.
      */

--- a/Sources/RichTextKit/Extensions/String+Subscript.swift
+++ b/Sources/RichTextKit/Extensions/String+Subscript.swift
@@ -11,53 +11,53 @@ import Foundation
 /**
  This extension makes it possible to fetch characters from a
  string, as discussed here:
- 
+
  https://stackoverflow.com/questions/24092884/get-nth-character-of-a-string-in-swift-programming-language
  */
 public extension StringProtocol {
-    
+
     func character(at index: Int) -> String.Element? {
         if index < 0 { return nil }
         guard count > index else { return nil }
         return self[index]
     }
-    
+
     func character(at index: UInt) -> String.Element? {
         character(at: Int(index))
     }
-    
+
     subscript(_ offset: Int) -> Element {
         self[index(startIndex, offsetBy: offset)]
     }
-    
+
     subscript(_ range: Range<Int>) -> SubSequence {
         prefix(range.lowerBound+range.count).suffix(range.count)
     }
-    
+
     subscript(_ range: ClosedRange<Int>) -> SubSequence {
         prefix(range.lowerBound+range.count).suffix(range.count)
     }
-    
+
     subscript(_ range: PartialRangeThrough<Int>) -> SubSequence {
         prefix(range.upperBound.advanced(by: 1))
     }
-    
+
     subscript(_ range: PartialRangeUpTo<Int>) -> SubSequence {
         prefix(range.upperBound)
     }
-    
+
     subscript(_ range: PartialRangeFrom<Int>) -> SubSequence {
         suffix(Swift.max(0, count-range.lowerBound))
     }
 }
 
 private extension LosslessStringConvertible {
-    
+
     var string: String { .init(self) }
 }
 
 private extension BidirectionalCollection {
-    
+
     subscript(safe offset: Int) -> Element? {
         if isEmpty { return nil }
         guard let index = index(

--- a/Sources/RichTextKit/Focus/RichTextContextFocusedValueKey.swift
+++ b/Sources/RichTextKit/Focus/RichTextContextFocusedValueKey.swift
@@ -13,7 +13,7 @@ import SwiftUI
  ``RichTextContext`` instance in a multi-window app.
  */
 public struct RichTextContextFocusedValueKey: FocusedValueKey {
-    
+
     public typealias Value = RichTextContext
 }
 

--- a/Sources/RichTextKit/Fonts/FontDescriptorRepresentable.swift
+++ b/Sources/RichTextKit/Fonts/FontDescriptorRepresentable.swift
@@ -43,7 +43,7 @@ import UIKit
 public typealias FontDescriptorRepresentable = UIFontDescriptor
 
 public extension FontDescriptorRepresentable {
-    
+
     /// Get a new font descriptor by toggling a text style.
     func byTogglingStyle(_ style: RichTextStyle) -> FontDescriptorRepresentable {
         guard let traits = style.symbolicTraits else { return self }

--- a/Sources/RichTextKit/Fonts/FontRepresentable.swift
+++ b/Sources/RichTextKit/Fonts/FontRepresentable.swift
@@ -21,7 +21,7 @@ import AppKit
 
 /**
  This typealias bridges platform-specific fonts, to simplify
- multi-platform support. 
+ multi-platform support.
  */
 public typealias FontRepresentable = NSFont
 #endif

--- a/Sources/RichTextKit/Fonts/FontTraitsRepresentable.swift
+++ b/Sources/RichTextKit/Fonts/FontTraitsRepresentable.swift
@@ -27,7 +27,7 @@ import UIKit
  simplify multi-platform support.
 
  The typealias also defines additional functionality as type
- extensions for the platform-specific types. 
+ extensions for the platform-specific types.
  */
 public typealias FontTraitsRepresentable = UIFontDescriptor.SymbolicTraits
 #endif

--- a/Sources/RichTextKit/Fonts/RichTextFontForEachPicker.swift
+++ b/Sources/RichTextKit/Fonts/RichTextFontForEachPicker.swift
@@ -25,10 +25,10 @@ import SwiftUI
  want to use a plain `List`.
  */
 public struct RichTextFontForEachPicker: View {
-    
+
     /**
      Create a font picker.
-     
+
      - Parameters:
        - selection: The selected font name.
        - selectionTopmost: Whether or not to place the selected font topmost.
@@ -57,16 +57,16 @@ public struct RichTextFontForEachPicker: View {
     private var fonts: [RichTextFontPickerFont]
     private let fontSize: CGFloat
     private let dismissAfterPick: Bool
-    
+
     @Binding
     private var selection: FontName
-    
+
     public var body: some View {
         let font = Binding(
             get: { RichTextFontPickerFont(fontName: selection) },
             set: { selection = $0.fontName }
         )
-        
+
         ForEachPicker(
             items: fonts,
             selection: font,
@@ -82,11 +82,11 @@ public struct RichTextFontForEachPicker: View {
 }
 
 struct RichTextFontForEachPicker_Previews: PreviewProvider {
-    
+
     struct Preview: View {
-        
+
         @State private var font = ""
-        
+
         var body: some View {
             NavigationView {
                 List {
@@ -96,7 +96,7 @@ struct RichTextFontForEachPicker_Previews: PreviewProvider {
             }
         }
     }
-    
+
     static var previews: some View {
         Preview()
     }

--- a/Sources/RichTextKit/Fonts/RichTextFontListPicker.swift
+++ b/Sources/RichTextKit/Fonts/RichTextFontListPicker.swift
@@ -24,10 +24,10 @@ import SwiftUI
  control over hot items are listed.
  */
 public struct RichTextFontListPicker: View {
-    
+
     /**
      Create a font picker.
-     
+
      - Parameters:
        - selection: The selected font name.
        - selectionTopmost: Whether or not to place the selected font topmost.
@@ -56,16 +56,16 @@ public struct RichTextFontListPicker: View {
     private var fonts: [RichTextFontPickerFont]
     private let fontSize: CGFloat
     private let dismissAfterPick: Bool
-    
+
     @Binding
     private var selection: FontName
-    
+
     public var body: some View {
         let font = Binding(
             get: { RichTextFontPickerFont(fontName: selection) },
             set: { selection = $0.fontName }
         )
-        
+
         ListPicker(
             items: fonts,
             selection: font,
@@ -81,11 +81,11 @@ public struct RichTextFontListPicker: View {
 }
 
 struct RichTextFontListPicker_Previews: PreviewProvider {
-    
+
     struct Preview: View {
-        
+
         @State private var font = ""
-        
+
         var body: some View {
             NavigationView {
                 RichTextFontListPicker(
@@ -95,7 +95,7 @@ struct RichTextFontListPicker_Previews: PreviewProvider {
             }
         }
     }
-    
+
     static var previews: some View {
         Preview()
     }

--- a/Sources/RichTextKit/Fonts/RichTextFontPicker.swift
+++ b/Sources/RichTextKit/Fonts/RichTextFontPicker.swift
@@ -22,10 +22,10 @@ import SwiftUI
  instead, which can be more customized.
  */
 public struct RichTextFontPicker: View {
-    
+
     /**
      Create a font picker.
-     
+
      - Parameters:
        - selection: The selected font name.
        - fonts: The fonts to display in the list, by default `all`.
@@ -43,14 +43,14 @@ public struct RichTextFontPicker: View {
     }
 
     public typealias FontName = String
-    
+
     private let fonts: [RichTextFontPickerFont]
     private let itemFontSize: CGFloat
     private let selectedFont: RichTextFontPickerFont?
-    
+
     @Binding
     private var selection: FontName
-    
+
     public var body: some View {
         Picker(selection: $selection) {
             ForEach(fonts) { font in
@@ -67,7 +67,7 @@ public struct RichTextFontPicker: View {
 }
 
 private extension RichTextFontPickerFont {
-    
+
     /**
      A system font has a font name that may be resolved to a
      different font name when it's picked. We must therefore
@@ -84,7 +84,7 @@ private extension RichTextFontPickerFont {
         if selected.hasPrefix(fontName.replacingOccurrences(of: " ", with: "-")) { return true }
         return false
     }
-    
+
     /**
      Use the selected font name as tag for the selected font.
      */
@@ -95,12 +95,12 @@ private extension RichTextFontPickerFont {
 }
 
 struct FontPicker_Previews: PreviewProvider {
-    
+
     struct Preview: View {
-        
+
         @State
         private var selection = ""
-        
+
         var body: some View {
             NavigationView {
                 RichTextFontPicker(selection: $selection)
@@ -109,14 +109,14 @@ struct FontPicker_Previews: PreviewProvider {
             }
         }
     }
-    
+
     static var previews: some View {
         Preview()
     }
 }
 
 private extension View {
-    
+
     @ViewBuilder
     func withStyle() -> some View {
         #if iOS || macOS

--- a/Sources/RichTextKit/Fonts/RichTextFontPickerFont.swift
+++ b/Sources/RichTextKit/Fonts/RichTextFontPickerFont.swift
@@ -102,7 +102,7 @@ public extension RichTextFontPickerFont {
 // MARK: - Public Properties
 
 public extension RichTextFontPickerFont {
-    
+
     /**
      Get the display name for the font.
 
@@ -114,7 +114,7 @@ public extension RichTextFontPickerFont {
         let systemName = Self.standardSystemFontDisplayName
         return isSystemFont ? systemName : fontName
     }
-    
+
     /**
      Check whether or not a certain font name represents the
      standard system font (e.g. San Francisco for iOS).
@@ -160,7 +160,7 @@ public extension Collection where Element == RichTextFontPickerFont {
 // MARK: - System Fonts
 
 private extension RichTextFontPickerFont {
-    
+
     /**
      Get all available font picker fonts.
      */

--- a/Sources/RichTextKit/Fonts/RichTextFontPickerItem.swift
+++ b/Sources/RichTextKit/Fonts/RichTextFontPickerItem.swift
@@ -24,13 +24,13 @@ struct RichTextFontPickerItem: View, ListPickerItem {
     }
 
     typealias Item = RichTextFontPickerFont
-    
+
     let font: RichTextFontPickerFont
     let fontSize: CGFloat
     let isSelected: Bool
 
     var item: RichTextFontPickerFont { font }
-    
+
     var body: some View {
         HStack {
             Text(font.fontDisplayName)

--- a/Sources/RichTextKit/Images/Image+RichText.swift
+++ b/Sources/RichTextKit/Images/Image+RichText.swift
@@ -18,17 +18,17 @@ public extension Image {
     static let richTextActionRedo = symbol("arrow.uturn.forward")
     static let richTextActionShare = symbol("square.and.arrow.up")
     static let richTextActionUndo = symbol("arrow.uturn.backward")
-    
+
     static let richTextAlignmentCenter = symbol("text.aligncenter")
     static let richTextAlignmentJustified = symbol("text.justify")
     static let richTextAlignmentLeft = symbol("text.alignleft")
     static let richTextAlignmentRight = symbol("text.alignright")
-    
+
     static let richTextColorBackground = symbol("highlighter")
     static let richTextColorForeground = symbol("character")
     static let richTextColorStroke = symbol("a.square")
     static let richTextColorStrikethrough = symbol("strikethrough")
-    
+
     static let richTextDocument = symbol("doc.text")
     static let richTextDocuments = symbol("doc.on.doc")
 

--- a/Sources/RichTextKit/Images/RichTextImageAttachment.swift
+++ b/Sources/RichTextKit/Images/RichTextImageAttachment.swift
@@ -20,12 +20,12 @@ import UniformTypeIdentifiers
 /**
  This custom attachment type inherits `NSTextAttachment` and
  aims to solve multi-platform image attachment problems.
- 
+
  When using `NSTextAttachment` directly, any images added by
  iOS can't be loaded on macOS, and vice versa. To solve this,
  this custom attachment class uses the `contents` data, then
  overrides `image` on iOS and `attachmentCell` on macOS.
- 
+
  This is probably the wrong way to solve this problem, but I
  haven't been able to find another way. If we set the `image`
  property of a plain `NSTextAttachment`, it works to add and
@@ -38,7 +38,7 @@ import UniformTypeIdentifiers
  attachments as (potentially) huge png data. This attachment
  allows you to easily use jpg with a custom compression rate
  instead, which results in much smaller files.
- 
+
  # WARNING
 
  If we use ``RichTextDataFormat/archivedData`` to persist an
@@ -155,7 +155,7 @@ open class RichTextImageAttachment: NSTextAttachment {
      */
     public override class var supportsSecureCoding: Bool { true }
 
-    
+
     #if iOS || os(tvOS)
     /**
      Get or set the attachment image.
@@ -173,7 +173,7 @@ open class RichTextImageAttachment: NSTextAttachment {
         }
     }
     #endif
-    
+
     #if macOS
     /**
      Get or set the attachment image.

--- a/Sources/RichTextKit/Images/RichTextImageAttachmentSize.swift
+++ b/Sources/RichTextKit/Images/RichTextImageAttachmentSize.swift
@@ -13,16 +13,16 @@ import CoreGraphics
  used in a rich text.
  */
 public enum RichTextImageAttachmentSize {
-    
+
     /// This size aims to make image fit the frame.
     case frame
-    
+
     /// This size aims to make image fit the size in points.
     case points(CGFloat)
 }
 
 public extension RichTextImageAttachmentSize {
-    
+
     /**
      The image's resulting height in a certain frame.
      */
@@ -32,7 +32,7 @@ public extension RichTextImageAttachmentSize {
         case .points(let points): return points
         }
     }
-    
+
     /**
      The image's resulting width in a certain frame.
      */

--- a/Sources/RichTextKit/Images/RichTextImageConfiguration.swift
+++ b/Sources/RichTextKit/Images/RichTextImageConfiguration.swift
@@ -11,16 +11,16 @@ import Foundation
 /**
  This struct can be used to configure how images are handled
  in e.g. a ``RichTextView``.
- 
+
  The paste and drop configurations should be `.disabled` for
  rich text formats that don't support inserting images, like
  .txt and .rtf (where images must be added to a sub-folder).
  */
 public struct RichTextImageConfiguration {
-    
+
     /**
      Create a rich text image configuration.
-     
+
      - Parameters:
        - pasteConfiguration: The configuration to use when pasting images.
        - dropConfiguration: The configuration to use when dropping images.
@@ -35,19 +35,19 @@ public struct RichTextImageConfiguration {
         self.dropConfiguration = dropConfiguration
         self.maxImageSize = maxImageSize
     }
-    
+
     /// The image configuration to use when dropping images.
     public var dropConfiguration: RichTextImageInsertConfiguration
-    
+
     /// The max size to limit images in the text view to.
     public var maxImageSize: (width: RichTextImageAttachmentSize, height: RichTextImageAttachmentSize)
-    
+
     /// The image configuration to use when pasting images.
     public var pasteConfiguration: RichTextImageInsertConfiguration
 }
 
 public extension RichTextImageConfiguration {
-    
+
     /// Get a disabled image configuration.
     static var disabled: RichTextImageConfiguration {
         RichTextImageConfiguration(

--- a/Sources/RichTextKit/Images/RichTextImageInsertConfiguration.swift
+++ b/Sources/RichTextKit/Images/RichTextImageInsertConfiguration.swift
@@ -11,20 +11,20 @@ import Foundation
 /**
  This enum can be used to configure the image drop and paste
  behavior of a ``RichTextView``.
- 
+
  The configuration is needed, since ``RichTextDataFormat/rtf``
  and ``RichTextDataFormat/plainText`` doesn't support images
  and a text view does not know the format of the string that
  it contains.
  */
 public enum RichTextImageInsertConfiguration: Equatable {
-    
+
     /// Image inserting is disabled
     case disabled
-    
+
     /// Image inserting is enabled but aborts with a warning
     case disabledWithWarning(title: String, message: String)
-    
+
     /// Image inserting is enabled
     case enabled
 }

--- a/Sources/RichTextKit/Keyboard/RichTextKeyboardToolbar.swift
+++ b/Sources/RichTextKit/Keyboard/RichTextKeyboardToolbar.swift
@@ -151,7 +151,7 @@ extension UIApplication {
 }
 
 private extension View {
-    
+
     @ViewBuilder
     func prefersMediumSize() -> some View {
         if #available(iOS 16, *) {

--- a/Sources/RichTextKit/Localization/RTKL10n.swift
+++ b/Sources/RichTextKit/Localization/RTKL10n.swift
@@ -61,7 +61,7 @@ public enum RTKL10n: String, CaseIterable, Identifiable {
     textAlignmentRight,
     textAlignmentCentered,
     textAlignmentJustified,
-    
+
     indent
 }
 
@@ -77,24 +77,24 @@ public extension RTKL10n {
 }
 
 public extension RTKL10n {
-    
+
     /**
      The item's unique identifier.
      */
     var id: String { rawValue }
-    
+
     /**
      The item's localization key.
      */
     var key: String { rawValue }
-    
+
     /**
      The item's localized text.
      */
     var text: String {
         text(for: .current)
     }
-    
+
     /**
      Get the localized text for a certain `Locale`.
      */
@@ -114,7 +114,7 @@ struct RTKL10n_Previews: PreviewProvider {
         .init(identifier: "nb"),
         .init(identifier: "sv")
     ]
-    
+
     static var previews: some View {
         NavigationView {
             List {

--- a/Sources/RichTextKit/Pdf/PdfPageConfiguration.swift
+++ b/Sources/RichTextKit/Pdf/PdfPageConfiguration.swift
@@ -26,7 +26,7 @@ public struct PdfPageConfiguration: Equatable {
         self.pageSize = pageSize
         self.pageMargins = pageMargins
     }
-    
+
     /// The page size in points.
     public var pageSize: CGSize
 

--- a/Sources/RichTextKit/Pdf/PdfPageMargins.swift
+++ b/Sources/RichTextKit/Pdf/PdfPageMargins.swift
@@ -55,7 +55,7 @@ public struct PdfPageMargins: Equatable {
         self.bottom = all
         self.right = all
     }
-    
+
     /// The top margins.
     public var top: CGFloat
 

--- a/Sources/RichTextKit/RichTextEditor.swift
+++ b/Sources/RichTextKit/RichTextEditor.swift
@@ -17,12 +17,12 @@ import SwiftUI
  make view and context changes sync correctly. You will then
  be able to use the `richTextContext` to trigger and observe
  changes to the text editor.
- 
+
  Note that changing the value of the `text` binding from the
  outside will not (yet) update the editor. Until it is fixed,
  use ``RichTextContext/setAttributedString(to:)`` to set the
  string to another value.
- 
+
  Since the view wraps a native `UIKit` or `AppKit` text view,
  you can't apply `.toolbar` modifiers to it, like you can do
  with other SwiftUI views. This means that this doesn't work:
@@ -71,7 +71,7 @@ public struct RichTextEditor: ViewRepresentable {
 
 
     private var format: RichTextDataFormat
-    
+
     private var text: Binding<NSAttributedString>
 
     @ObservedObject

--- a/Sources/RichTextKit/RichTextPresenter.swift
+++ b/Sources/RichTextKit/RichTextPresenter.swift
@@ -17,7 +17,7 @@ import Foundation
  the platform-specific ``RichTextView`` components.
  */
 public protocol RichTextPresenter: RichTextReader {
-    
+
     /// Get the currently selected range.
     var selectedRange: NSRange { get }
 }
@@ -35,14 +35,14 @@ public extension RichTextPresenter {
         let trimmed = string.trimmingCharacters(in: .whitespaces)
         return !trimmed.isEmpty
     }
-    
+
     /// Get the range after the input cursor.
     var rangeAfterInputCursor: NSRange {
         let location = selectedRange.location
         let length = richText.length - location
         return NSRange(location: location, length: length)
     }
-    
+
     /// Get the range before the input cursor.
     var rangeBeforeInputCursor: NSRange {
         let location = selectedRange.location

--- a/Sources/RichTextKit/RichTextView_AppKit.swift
+++ b/Sources/RichTextKit/RichTextView_AppKit.swift
@@ -17,7 +17,7 @@ import AppKit
  in UIKit. It aims to make these views behave more alike and
  make them implement ``RichTextViewComponent``, which is the
  protocol that is used within this library.
- 
+
  The view will apply a ``RichTextImageConfiguration/disabled``
  image config by default. You can change this by setting the
  property manually or by using a ``RichTextDataFormat`` that
@@ -26,7 +26,7 @@ import AppKit
 open class RichTextView: NSTextView, RichTextViewComponent {
 
     // MARK: - Properties
-    
+
     /// The style to use when highlighting text in the view.
     public var highlightingStyle: RichTextHighlightingStyle = .standard
 
@@ -71,7 +71,7 @@ open class RichTextView: NSTextView, RichTextViewComponent {
             pasteImages(images, at: selectedRange().location, moveCursorToPastedContent: true)
             return true
         }
-        
+
         return super.performDragOperation(draggingInfo)
     }
 

--- a/Sources/RichTextKit/RichTextView_UIKit.swift
+++ b/Sources/RichTextKit/RichTextView_UIKit.swift
@@ -319,7 +319,7 @@ open class RichTextView: UITextView, RichTextViewComponent {
             strings.forEach { self.pasteText($0, at: range.location) }
         }
     }
-    
+
     /// Refresh the drop interaction based on the config.
     open func refreshDropInteraction() {
         switch imageDropConfiguration {

--- a/Sources/RichTextKit/Sharing/RichTextShareService.swift
+++ b/Sources/RichTextKit/Sharing/RichTextShareService.swift
@@ -18,11 +18,11 @@ import Foundation
  format, should use a ``RichTextExportService`` instead.
  */
 public protocol RichTextShareService: AnyObject {
-    
+
     /**
      Generate a share file with a certain name and rich text
      content, that uses a certain rich text data format.
-     
+
      - Parameters:
        - withName: The name of the shared file.
        - content: The rich text content to share.
@@ -33,11 +33,11 @@ public protocol RichTextShareService: AnyObject {
         content: NSAttributedString,
         format: RichTextDataFormat
     ) throws -> URL
-    
+
     /**
      Generate a PDF formatted share file with a certain name
      and rich text content.
-     
+
      - Parameters:
        - withName: The name of the shared file.
        - content: The rich text content to share.

--- a/Sources/RichTextKit/Sharing/StandardRichTextShareService.swift
+++ b/Sources/RichTextKit/Sharing/StandardRichTextShareService.swift
@@ -33,14 +33,14 @@ public class StandardRichTextShareService: RichTextShareService {
 
     private let urlResolver: RichTextExportUrlResolver
     private let directory: FileManager.SearchPathDirectory
-    
+
     /**
      Generate a file with a certain name, content and format.
 
      Share files will by default be added to the app's cache
      folder, which means that we don't have to care about if
      a file with the same name already exists.
-     
+
      - Parameters:
        - fileName: The name of the shared file.
        - content: The rich text content to share.
@@ -59,14 +59,14 @@ public class StandardRichTextShareService: RichTextShareService {
         try data.write(to: fileUrl)
         return fileUrl
     }
-    
+
     /**
      Generate a PDF share file with a certain text content.
 
      Share files will by default be added to the app's cache
      folder, which means that we don't have to care about if
      a file with the same name already exists.
-     
+
      - Parameters:
        - fileName: The name of the shared file.
        - content: The rich text content to share.

--- a/Sources/RichTextKit/Styles/RichTextHighlightingStyle.swift
+++ b/Sources/RichTextKit/Styles/RichTextHighlightingStyle.swift
@@ -12,7 +12,7 @@ import SwiftUI
  This struct can be used to style rich text highlighting.
  */
 public struct RichTextHighlightingStyle: Equatable {
-    
+
     /**
      Create a style instance.
 
@@ -27,10 +27,10 @@ public struct RichTextHighlightingStyle: Equatable {
         self.backgroundColor = backgroundColor
         self.foregroundColor = foregroundColor
     }
-    
+
     /// The background color to use for highlighted text.
     public let backgroundColor: Color
-    
+
     /// The foreground color to use for highlighted text.
     public let foregroundColor: Color
 }
@@ -40,7 +40,7 @@ public extension RichTextHighlightingStyle {
     /**
      The standard rich text highlighting style, which uses a
      clear background color and an accent foreground color.
-     
+
      You can override this value to change the global style.
      */
     static var standard = RichTextHighlightingStyle()

--- a/Sources/RichTextKit/Views/ForEachPicker.swift
+++ b/Sources/RichTextKit/Views/ForEachPicker.swift
@@ -27,17 +27,17 @@ struct ForEachPicker<Item: Identifiable, ItemView: View>: View {
         self.dismissAfterPick = dismissAfterPick
         self.listItem = listItem
     }
-    
+
     private let items: [Item]
     private let selection: Binding<Item>
     private let animatedSelection: Bool
     private let dismissAfterPick: Bool
     private let listItem: ItemViewBuilder
-    
+
     typealias ItemViewBuilder = (_ item: Item, _ isSelected: Bool) -> ItemView
-    
+
     @Environment(\.presentationMode) var presentationMode
-    
+
     var body: some View {
         ForEach(items) { item in
             Button(action: { select(item) }, label: {
@@ -48,7 +48,7 @@ struct ForEachPicker<Item: Identifiable, ItemView: View>: View {
 }
 
 private extension ForEachPicker {
-    
+
     var selectedId: Item.ID {
         selection.wrappedValue.id
     }
@@ -59,11 +59,11 @@ private extension ForEachPicker {
     func dismiss() {
         presentationMode.wrappedValue.dismiss()
     }
-    
+
     func isSelected(_ item: Item) -> Bool {
         selectedId == item.id
     }
-    
+
     func select(_ item: Item) {
         if animatedSelection {
             selectWithAnimation(item)
@@ -71,13 +71,13 @@ private extension ForEachPicker {
             selectWithoutAnimation(item)
         }
     }
-    
+
     func selectWithAnimation(_ item: Item) {
         withAnimation {
             selectWithoutAnimation(item)
         }
     }
-    
+
     func selectWithoutAnimation(_ item: Item) {
         selection.wrappedValue = item
         if dismissAfterPick {

--- a/Sources/RichTextKit/Views/ListPicker.swift
+++ b/Sources/RichTextKit/Views/ListPicker.swift
@@ -41,17 +41,17 @@ struct ListPicker<Item: Identifiable, ItemView: View>: View {
         self.dismissAfterPick = dismissAfterPick
         self.listItem = listItem
     }
-    
+
     private let sections: [ListPickerSection<Item>]
     private let selection: Binding<Item>
     private let animatedSelection: Bool
     private let dismissAfterPick: Bool
     private let listItem: ItemViewBuilder
-    
+
     typealias ItemViewBuilder = (_ item: Item, _ isSelected: Bool) -> ItemView
-    
+
     @Environment(\.presentationMode) var presentationMode
-    
+
     var body: some View {
         List {
             ForEach(sections) { section in

--- a/Sources/RichTextKit/Views/ListPickerItem.swift
+++ b/Sources/RichTextKit/Views/ListPickerItem.swift
@@ -14,15 +14,15 @@ import SwiftUI
  This will not be made public or documented for this library.
  */
 protocol ListPickerItem: View {
-    
+
     associatedtype Item: Equatable
-    
+
     var item: Item { get }
     var isSelected: Bool { get }
 }
 
 extension ListPickerItem {
-    
+
     var checkmark: some View {
         Image(systemName: "checkmark")
             .opacity(isSelected ? 1 : 0)

--- a/Sources/RichTextKit/Views/ListPickerSection.swift
+++ b/Sources/RichTextKit/Views/ListPickerSection.swift
@@ -11,20 +11,20 @@ import SwiftUI
 /**
  This is an internal version of the original that is defined
  and available in https://github.com/danielsaidi/swiftuikit.
- This will not be made public or documented for this library. 
+ This will not be made public or documented for this library.
  */
 struct ListPickerSection<Item: Identifiable>: Identifiable {
-    
+
     init(title: String, items: [Item]) {
         self.id = UUID()
         self.title = title
         self.items = items
     }
-    
+
     let id: UUID
     let title: String
     let items: [Item]
-    
+
     @ViewBuilder
     var header: some View {
         if title.trimmingCharacters(in: .whitespaces).isEmpty {

--- a/Sources/RichTextKit/_Deprecated/ReadersWriters+Deprecated.swift
+++ b/Sources/RichTextKit/_Deprecated/ReadersWriters+Deprecated.swift
@@ -31,21 +31,21 @@ public protocol RichTextStyleReader: RichTextAttributeReader {}
 public protocol RichTextStyleWriter: RichTextAttributeWriter, RichTextStyleReader {}
 
 public extension RichTextAttributeReader {
-    
+
     @available(*, deprecated, renamed: "richTextBackgroundColor(at:)")
     func backgroundColor(
         at range: NSRange
     ) -> ColorRepresentable? {
         richTextAttribute(.backgroundColor, at: range)
     }
-    
+
     @available(*, deprecated, renamed: "richTextForegroundColor(at:)")
     func foregroundColor(
         at range: NSRange
     ) -> ColorRepresentable? {
         richTextAttribute(.foregroundColor, at: range)
     }
-    
+
     @available(*, deprecated, renamed: "richTextFont(at:)")
     func font(at range: NSRange) -> FontRepresentable? {
         richTextFont(at: range)
@@ -58,7 +58,7 @@ public extension RichTextAttributeReader {
 }
 
 public extension RichTextAttributeWriter {
-    
+
     @available(*, deprecated, renamed: "setRichTextBackgroundColor(_:at:)")
     func setBackgroundColor(
         to color: ColorRepresentable,
@@ -66,7 +66,7 @@ public extension RichTextAttributeWriter {
     ) {
         setRichTextBackgroundColor(color, at: range)
     }
-    
+
     @available(*, deprecated, renamed: "setFont(_:at:)")
     func setFont(
         to font: FontRepresentable,
@@ -98,7 +98,7 @@ public extension RichTextAttributeWriter {
     ) {
         setRichTextForegroundColor(color, at: range)
     }
-    
+
     @available(*, deprecated, renamed: "setRichTextAlignment(_:at:)")
     func setRichTextAlignment(
         to alignment: RichTextAlignment,
@@ -106,7 +106,7 @@ public extension RichTextAttributeWriter {
     ) {
         setRichTextAlignment(alignment, at: range)
     }
-    
+
     @available(*, deprecated, renamed: "setRichTextFont(_:at:)")
     func setFont(
         _ font: FontRepresentable,
@@ -114,7 +114,7 @@ public extension RichTextAttributeWriter {
     ) {
         setRichTextFont(font, at: range)
     }
-    
+
     @available(*, deprecated, renamed: "setRichTextFontName(_:at:)")
     func setFontName(
         _ name: String,
@@ -122,7 +122,7 @@ public extension RichTextAttributeWriter {
     ) {
         setRichTextFontName(name, at: range)
     }
-    
+
     @available(*, deprecated, renamed: "setRichTextFontSize(_:at:)")
     func setFontSize(
         _ size: CGFloat,
@@ -130,7 +130,7 @@ public extension RichTextAttributeWriter {
     ) {
         setRichTextFontSize(size, at: range)
     }
-    
+
     @available(*, deprecated, renamed: "stepRichTextIndent(_:at:)")
     func setRichTextIndent(
         to indent: RichTextIndent,
@@ -144,7 +144,7 @@ public extension RichTextAttributeWriter {
             at: range
         )
     }
-    
+
     @available(*, deprecated, renamed: "stepRichTextFontSize(points:at:)")
     func stepFontSize(
         points: Int,
@@ -152,7 +152,7 @@ public extension RichTextAttributeWriter {
     ) {
         stepRichTextFontSize(points: points, at: range)
     }
-    
+
     @available(*, deprecated, message: "Use stepRichTextFontSize instead")
     func decrementFontSize(
         points: UInt = 1,

--- a/Sources/RichTextKit/_Deprecated/RichTextAction+Deprecated.swift
+++ b/Sources/RichTextKit/_Deprecated/RichTextAction+Deprecated.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 public extension RichTextAction {
-    
+
     @available(*, deprecated, renamed: "increaseFontSize")
     static var incrementFontSize: RichTextAction { stepFontSize(points: 1) }
 

--- a/Sources/RichTextKit/_Deprecated/RichTextColorPicker+Deprecated.swift
+++ b/Sources/RichTextKit/_Deprecated/RichTextColorPicker+Deprecated.swift
@@ -3,7 +3,7 @@ import SwiftUI
 
 @available(*, deprecated, renamed: "init(icon:value:showIcon:quickColors:)")
 public extension RichTextColorPicker {
-    
+
     init(
         color: PickerColor,
         value: Binding<Color>,
@@ -16,7 +16,7 @@ public extension RichTextColorPicker {
             quickColors: quickColors
         )
     }
-    
+
     init(
         color: PickerColor,
         value: Binding<Color>,
@@ -30,7 +30,7 @@ public extension RichTextColorPicker {
             quickColors: quickPickerColors.colors
         )
     }
-    
+
     init(
         color: PickerColor,
         context: RichTextContext,
@@ -49,7 +49,7 @@ public extension RichTextColorPicker {
             quickColors: quickColors
         )
     }
-    
+
     init(
         color: PickerColor,
         context: RichTextContext,

--- a/Sources/RichTextKit/_Deprecated/RichTextContext+Deprecated.swift
+++ b/Sources/RichTextKit/_Deprecated/RichTextContext+Deprecated.swift
@@ -1,32 +1,32 @@
 import SwiftUI
 
 public extension RichTextContext {
-    
+
     @available(*, deprecated, message: "Use handle(_:) instead")
     func decrementFontSize(points: UInt = 1) {
         handle(.decreaseFontSize(points: points))
     }
-    
+
     @available(*, deprecated, message: "Use handle(_:) instead")
     func incrementFontSize(points: UInt = 1) {
         handle(.increaseFontSize(points: points))
     }
-    
+
     @available(*, deprecated, message: "Use handle(_:) instead")
     func increaseFontSize(points: UInt = 1) {
         handle(.increaseFontSize(points: points))
     }
-    
+
     @available(*, deprecated, message: "Use handle(_:) instead")
     func decreaseFontSize(points: UInt = 1) {
         handle(.decreaseFontSize(points: points))
     }
-    
+
     @available(*, deprecated, message: "Use handle(_:) instead")
     func increaseIndent(points: UInt = 1) {
         handle(.increaseIndent(points: points))
     }
-    
+
     @available(*, deprecated, message: "Use handle(_:) instead")
     func decreaseIndent(points: UInt = 1) {
         handle(.decreaseIndent(points: points))

--- a/Sources/RichTextKit/_Deprecated/RichTextIndent+Deprecated.swift
+++ b/Sources/RichTextKit/_Deprecated/RichTextIndent+Deprecated.swift
@@ -2,10 +2,10 @@ import SwiftUI
 
 @available(*, deprecated, message: "This type is no longer used")
 public enum RichTextIndent: CaseIterable, Codable, Equatable, Identifiable {
-    
+
     /// Reduce indent space.
     case decrease
-    
+
     /// Increase indent space.
     case increase
 }
@@ -15,7 +15,7 @@ public extension RichTextIndent {
 
     /// The indent's unique ID.
     var id: UUID { UUID() }
-    
+
     /// The indent's standard icon.
     var icon: Image {
         switch self {

--- a/Sources/RichTextKit/_Deprecated/RichTextIndentPicker.swift
+++ b/Sources/RichTextKit/_Deprecated/RichTextIndentPicker.swift
@@ -23,7 +23,7 @@ public struct RichTextIndentPicker: View {
 
     @Binding
     private var selection: RichTextIndent
-    
+
     public var body: some View {
         Picker("", selection: $selection) {
             ForEach(RichTextIndent.allCases) {

--- a/Sources/RichTextKit/_Deprecated/RichTextViewComponent+Deprecated.swift
+++ b/Sources/RichTextKit/_Deprecated/RichTextViewComponent+Deprecated.swift
@@ -1,8 +1,8 @@
 import Foundation
 
 public extension RichTextViewComponent {
-    
-    
+
+
     @available(*, deprecated, renamed: "currentColor(_:)")
     var currentBackgroundColor: ColorRepresentable? {
         currentColor(.background)
@@ -12,7 +12,7 @@ public extension RichTextViewComponent {
     var currentForegroundColor: ColorRepresentable? {
         currentColor(.foreground)
     }
-    
+
     @available(*, deprecated, renamed: "currentColor(_:)")
     var currentStrokeColor: ColorRepresentable? {
         currentColor(.stroke)
@@ -22,54 +22,54 @@ public extension RichTextViewComponent {
     var currentStrikethroughColor: ColorRepresentable? {
         currentColor(.strikethrough)
     }
-    
+
     @available(*, deprecated, renamed: "setCurrentColor(_:to:)")
     func setCurrentBackgroundColor(
         _ color: ColorRepresentable
     ) {
         setCurrentColor(.background, to: color)
     }
-    
+
     @available(*, deprecated, renamed: "setCurrentColor(_:to:)")
     func setCurrentForegroundColor(
         _ color: ColorRepresentable
     ) {
         setCurrentColor(.foreground, to: color)
     }
-    
+
     @available(*, deprecated, renamed: "setCurrentColor(_:to:)")
     func setCurrentStrokeColor(
         _ color: ColorRepresentable
     ) {
         setCurrentColor(.stroke, to: color)
     }
-    
+
     @available(*, deprecated, renamed: "setCurrentColor(_:to:)")
     func setCurrentStrikethroughColor(
         _ color: ColorRepresentable
     ) {
         setCurrentColor(.strikethrough, to: color)
     }
-    
+
     @available(*, deprecated, renamed: "currentTextAlignment")
     var currentRichTextAlignment: RichTextAlignment? {
         currentTextAlignment
     }
-    
+
     @available(*, deprecated, renamed: "setCurrentTextAlignment(_:)")
     func setCurrentRichTextAlignment(
         to alignment: RichTextAlignment
     ) {
         setCurrentTextAlignment(alignment)
     }
-    
+
     @available(*, deprecated, renamed: "setCurrentBackgroundColor(_:)")
     func setCurrentBackgroundColor(
         to color: ColorRepresentable
     ) {
         setCurrentBackgroundColor(color)
     }
-    
+
     @available(*, deprecated, renamed: "setCurrentForegroundColor(_:)")
     func setCurrentForegroundColor(
         to color: ColorRepresentable
@@ -81,22 +81,22 @@ public extension RichTextViewComponent {
     func setCurrentFont(to font: FontRepresentable) {
         setCurrentFont(font)
     }
-    
+
     @available(*, deprecated, renamed: "setCurrentFontName(_:)")
     func setCurrentFontName(to name: String) {
         setCurrentFontName(name)
     }
-    
+
     @available(*, deprecated, renamed: "setCurrentFontSize(_:)")
     func setCurrentFontSize(to size: CGFloat) {
         setCurrentFontSize(size)
     }
-    
+
     @available(*, deprecated, message: "Use stepCurrentFontSize instead.")
     func decrementCurrentFontSize(points: UInt = 1) {
         stepCurrentFontSize(points: -Int(points))
     }
-    
+
     @available(*, deprecated, message: "Use stepCurrentFontSize instead.")
     func incrementCurrentFontSize(points: UInt = 1) {
         stepCurrentFontSize(points: Int(points))

--- a/Tests/RichTextKitTests/Fonts/FontRepresentable+RichTextTests.swift
+++ b/Tests/RichTextKitTests/Fonts/FontRepresentable+RichTextTests.swift
@@ -10,7 +10,7 @@ import RichTextKit
 import XCTest
 
 final class FontRepresentable_RichTextTests: XCTestCase {
-    
+
     func testStandardRichTextFont() {
         let expected = FontRepresentable.systemFont(ofSize: .standardRichTextFontSize)
         XCTAssertEqual(FontRepresentable.standardRichTextFont, expected)

--- a/Tests/RichTextKitTests/RichTextContextTests.swift
+++ b/Tests/RichTextKitTests/RichTextContextTests.swift
@@ -10,7 +10,7 @@ import RichTextKit
 import XCTest
 
 final class RichTextContextTests: XCTestCase {
-    
+
     func testInitializerSetsDefaultValues() {
         let context = RichTextContext()
         XCTAssertEqual(context.fontName, "")

--- a/Tests/RichTextKitTests/RichTextCoordinator+SubscriptionsTests.swift
+++ b/Tests/RichTextKitTests/RichTextCoordinator+SubscriptionsTests.swift
@@ -12,7 +12,7 @@ import SwiftUI
 import XCTest
 
 final class RichTextCoordinator_SubscriptionsTests: XCTestCase {
-    
+
     private var text: NSAttributedString!
     private var textBinding: Binding<NSAttributedString>!
     private var textView: RichTextView!
@@ -40,7 +40,7 @@ final class RichTextCoordinator_SubscriptionsTests: XCTestCase {
         textView = nil
         textContext = nil
         coordinator = nil
-        
+
         super.tearDown()
     }
 

--- a/Tests/RichTextKitTests/RichTextPresenterTests.swift
+++ b/Tests/RichTextKitTests/RichTextPresenterTests.swift
@@ -53,13 +53,13 @@ final class RichTextPresenterTests: XCTestCase {
 }
 
 private class MockRichTextPresenter: RichTextPresenter {
-    
+
     init(text: NSAttributedString) {
         self.attributedString = text
         self.selectedRange = NSRange()
     }
-    
+
     var attributedString: NSAttributedString
-    
+
     var selectedRange: NSRange
 }

--- a/Tests/RichTextKitTests/RichTextReaderTests.swift
+++ b/Tests/RichTextKitTests/RichTextReaderTests.swift
@@ -10,7 +10,7 @@ import RichTextKit
 import XCTest
 
 final class RichTextReaderTests: XCTestCase {
-    
+
     private let string = NSAttributedString(string: "foo bar baz")
 
     func testRichTextAtRangeIsValidForEmptyRangeInEmptyString() {
@@ -67,14 +67,14 @@ final class RichTextReaderTests: XCTestCase {
         XCTAssertEqual(result.location, 8)
         XCTAssertEqual(result.length, 3)
     }
-    
+
     func testSafeRangeLimitsLocationToUpperLimit() {
         let range = NSRange(location: 12, length: 4)
         let result = string.safeRange(for: range)
         XCTAssertEqual(result.location, 11)
         XCTAssertEqual(result.length, 0)
     }
-    
+
     func testSafeRangeLimitsLocationToNextToUpperLimitForAttributes() {
         let range = NSRange(location: 12, length: 4)
         let result = string.safeRange(for: range, isAttributeOperation: true)

--- a/Tests/RichTextKitTests/RichTextViewRepresentable+FontSizeTests.swift
+++ b/Tests/RichTextKitTests/RichTextViewRepresentable+FontSizeTests.swift
@@ -37,7 +37,7 @@ final class RichTextViewComponent_FontSizeTests: XCTestCase {
             format: .rtf
         )
     }
-    
+
     override func tearDown() {
         textView = nil
 

--- a/Tests/RichTextKitTests/RichTextViewRepresentable+StylesTests.swift
+++ b/Tests/RichTextKitTests/RichTextViewRepresentable+StylesTests.swift
@@ -37,7 +37,7 @@ final class RichTextViewComponent_StylesTests: XCTestCase {
 
     override func tearDown() {
         textView = nil
-        
+
         super.tearDown()
     }
 

--- a/Tests/RichTextKitTests/RichTextViewRepresentableTests.swift
+++ b/Tests/RichTextKitTests/RichTextViewRepresentableTests.swift
@@ -19,7 +19,7 @@ final class RichTextViewComponentTests: XCTestCase {
 
         view = RichTextView()
     }
-    
+
     override func tearDown() {
         view = nil
 

--- a/Tests/RichTextKitTests/RichTextView_AppKitTests.swift
+++ b/Tests/RichTextKitTests/RichTextView_AppKitTests.swift
@@ -11,7 +11,7 @@ import XCTest
 @testable import RichTextKit
 
 final class TempTests: XCTestCase {
-    
+
     func testViewIsAccessible() {
         let view = RichTextView()
         XCTAssertNotNil(view)


### PR DESCRIPTION
## 🆕 Updated
Init [SwiftFormat](https://github.com/nicklockwood/SwiftFormat) - which can be gradually implemented - rule by rule.

Split into 2 commits
1. Define 1st rule - [`trailingSpace`](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#trailingSpace)
2. Run `swiftformat .` on the project.

## 🔮🚀 Possible Future Steps
- Adopt other rules
- GitHub action to check proper code format on PR - providing steps to fix if format not aligned
