### PR TITLE
Fix initial drag and drop on iOS

### DIFF
--- a/Sources/RichTextKit/RichTextView_UIKit.swift
+++ b/Sources/RichTextKit/RichTextView_UIKit.swift
@@ -206,7 +206,7 @@ open class RichTextView: UITextView, RichTextViewComponent {
 
     /// Get the text range at a certain point.
     open func range(at index: CGPoint) -> NSRange? {
-        guard let range = characterRange(at: index) else { return nil }
+        let range = characterRange(at: index) ?? UITextRange()
         let location = offset(from: beginningOfDocument, to: range.start)
         let length = offset(from: range.start, to: range.end)
         return NSRange(location: location, length: length)


### PR DESCRIPTION
# What this PR do:
- Fixes issue when on first drag and drop (and sometimes when there was empty textView with deleted text) the Drag and drop did not work.
# How to test it
- Run the app and drag and drop something from photos to RTE.

# Note
The configuration of text attributes on start will be implemented later, thus the black color of the text after the fix. 
 
| Before  | After |
| ------------- | ------------- |
| <video src="https://github.com/danielsaidi/RichTextKit/assets/17381941/841a1e74-ad96-4d4a-8595-b5c9a2d19d3a">  | <video src="https://github.com/danielsaidi/RichTextKit/assets/17381941/d71ebc6e-1355-4270-afc0-f7a80a0faa50">|