### PR TITLE
[Bugfix] Fix crashing of setRichTextColor

### DIFF
--- a/Sources/RichTextKit/Attributes/RichTextAttributeWriter+Colors.swift
+++ b/Sources/RichTextKit/Attributes/RichTextAttributeWriter+Colors.swift
@@ -18,6 +18,6 @@ public extension RichTextAttributeWriter {
     ) {
         guard let attribute = color.attribute else { return }
         if richTextColor(color, at: range) == val { return }
-        setRichTextAttribute(attribute, to: color, at: range)
+        setRichTextAttribute(attribute, to: val, at: range)
     }
 }


### PR DESCRIPTION
Writing description of PR would take longer time, but not longer than I was figuring the issue :D 

Long story short, setting instance of RichTextColor to any default NSAttribute causes crashes. So here is the fix :D 

This function is (not yet) used in the project, it will be used in https://github.com/danielsaidi/RichTextKit/pull/105