### PR TITLE
[BUGFIX] Fix attributes after pasting image

### DIFF
--- a/Sources/RichTextKit/Attributes/RichTextAttributeWriter+Font.swift
+++ b/Sources/RichTextKit/Attributes/RichTextAttributeWriter+Font.swift
@@ -93,7 +93,7 @@ private extension RichTextAttributeWriter {
     /// We must adjust empty font names on some platforms.
     func settableFontName(for fontName: String) -> String {
         #if macOS
-        fontName.isEmpty ? "Helvetica" : fontName
+        fontName
         #else
         fontName
         #endif

--- a/Sources/RichTextKit/Component/RichTextViewComponent+Font.swift
+++ b/Sources/RichTextKit/Component/RichTextViewComponent+Font.swift
@@ -13,7 +13,7 @@ public extension RichTextViewComponent {
 
     /// Get the current font.
     var currentFont: FontRepresentable? {
-        currentRichTextAttributes[.font] as? FontRepresentable
+        currentRichTextAttributes[.font] as? FontRepresentable ?? typingAttributes[.font] as? FontRepresentable
     }
 
     /// Get the current font size.

--- a/Sources/RichTextKit/Component/RichTextViewComponent+Pasting.swift
+++ b/Sources/RichTextKit/Component/RichTextViewComponent+Pasting.swift
@@ -70,12 +70,10 @@ public extension RichTextViewComponent {
         let isSelectedRange = (index == selectedRange.location)
         if isSelectedRange { deleteCharacters(in: selectedRange) }
         if move { moveInputCursor(to: index) }
-        let fontSize = currentFontSize
         images.reversed().forEach { performPasteImage($0, at: index) }
         if move { moveInputCursor(to: safeInsertRange.location + items) }
-        if move || isSelectedRange, let fontSize {
+        if move || isSelectedRange {
             DispatchQueue.main.async {
-                self.setRichTextFontSize(fontSize)
                 self.moveInputCursor(to: self.selectedRange.location)
             }
         }
@@ -135,10 +133,14 @@ private extension RichTextViewComponent {
         _ image: ImageRepresentable,
         at index: Int
     ) {
+        let newLine = NSAttributedString(string: "\n", attributes: currentRichTextAttributes)
         let content = NSMutableAttributedString(attributedString: richText)
         guard let insertString = getAttachmentString(for: image) else { return }
-        content.insert(NSAttributedString(string: "\n"), at: index)
+        
+        insertString.insert(newLine, at: insertString.length)
+        insertString.addAttributes(currentRichTextAttributes, range: insertString.richTextRange)
         content.insert(insertString, at: index)
+        
         setRichText(content)
     }
 }

--- a/Sources/RichTextKit/Coordinator/RichTextCoordinator.swift
+++ b/Sources/RichTextKit/Coordinator/RichTextCoordinator.swift
@@ -241,8 +241,9 @@ extension RichTextCoordinator {
             richTextContext.canUndoLatestChange = canUndo
         }
 
-        let fontName = textView.currentFontName ?? ""
-        if richTextContext.fontName != fontName {
+        if let fontName = textView.currentFontName,
+            !fontName.isEmpty,
+            richTextContext.fontName != fontName {
             richTextContext.fontName = fontName
         }
 

--- a/Sources/RichTextKit/Fonts/StandardFontSizeProvider.swift
+++ b/Sources/RichTextKit/Fonts/StandardFontSizeProvider.swift
@@ -42,11 +42,10 @@ public extension StandardFontSizeProvider {
      */
     static var standardRichTextFontSize: CGFloat {
         get { StandardFontSizeProviderStorage.standardRichTextFontSize }
-        set { StandardFontSizeProviderStorage.standardRichTextFontSize = newValue }
     }
 }
 
 private class StandardFontSizeProviderStorage {
 
-    static var standardRichTextFontSize: CGFloat = 16
+    static let standardRichTextFontSize: CGFloat = 16
 }


### PR DESCRIPTION
# What this PR do:
- Fixes an issue with attributedString not having the current attributes after pasting an image. This was caused by Image insertion not having Current RichTextView attributes, so it set the typing attributes at last index to none, basically using NS/UITextView default font and color (which is sadly not .textColor) and previous font size. This will be further improved with this [PR](https://github.com/DominikBucher12/RichTextKit/pull/1)
# How to test it
- Run the app, either drag and drop some image from photo gallery on iOS or paste the image. This should work for macOS too...

| Before | After |
|--------|--------|
| <video src ="https://github.com/danielsaidi/RichTextKit/assets/17381941/6187f742-5650-4b5c-8cf2-36f8bbd13d74"> | <video src ="https://github.com/danielsaidi/RichTextKit/assets/17381941/4d7c0faf-2756-482a-a6b0-4a8b2df2f98e"> | 