### PR TITLE
Fix GitHub Actions not supporting latest macOS SDK and runner

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: macos-13
     steps:
       - uses: actions/checkout@v3
       - uses: swift-actions/setup-swift@65540b95f51493d65f5e59e97dcef9629ddf11bf
@@ -19,8 +19,10 @@ jobs:
           swift-version: "5.8"
       - uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: latest-stable
-      - name: Build
-        run: swift build -v
-      - name: Run tests
-        run: swift test -v
+          xcode-version: '15.1.0'
+      - name: Build iOS
+        run: xcodebuild -project Demo/Demo.xcodeproj build -sdk iphoneos -scheme 'RichTextKit'
+      - name: Test iOS
+        run: xcodebuild -project Demo/Demo.xcodeproj test -sdk iphoneos -scheme 'RichTextKitTests' -destination 'platform=iOS Simulator,name=iPhone 15 Pro,OS=17.2' -enableCodeCoverage YES 
+
+          

--- a/Demo/Demo.xcodeproj/xcshareddata/xcschemes/RichTextKitTests.xcscheme
+++ b/Demo/Demo.xcodeproj/xcshareddata/xcschemes/RichTextKitTests.xcscheme
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1520"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "RichTextKitTests"
+               BuildableName = "RichTextKitTests"
+               BlueprintName = "RichTextKitTests"
+               ReferencedContainer = "container:..">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Sources/RichTextKit/Colors/RichTextColorPicker.swift
+++ b/Sources/RichTextKit/Colors/RichTextColorPicker.swift
@@ -149,10 +149,8 @@ private struct ColorButtonStyle: ButtonStyle {
     }
 }
 
-#Preview {
-
-    struct Preview: View {
-
+struct RichTextColorPicker_Previews: PreviewProvider {
+    private struct RichTextColorPickerPreview: View {
         @State
         private var foregroundColor = Color.black
 
@@ -187,5 +185,7 @@ private struct ColorButtonStyle: ButtonStyle {
         }
     }
 
-    return Preview()
+    static var previews: some View {
+        RichTextColorPickerPreview()
+    }
 }


### PR DESCRIPTION
# What this PR do:
- Aligns Preview for RichTextColor Picker to use old Preview structure.
- Updates Build action to use for now only iOS build and test
- MacOS will be added in separate PR in order for all PRs to be merged (and taken care of)
# Why no1
1. Unified Previews system
2. No compilation errors on newer systems
3. When unified with others, we can easily change this in future

# Why no2 
- Green builds
- Testing at last on each PR at least for iOS 
- CI is awesome.
