### PR TITLE
Add support to disable scrolling in text view

### DIFF
--- a/Sources/RichTextKit/Context/RichTextContext.swift
+++ b/Sources/RichTextKit/Context/RichTextContext.swift
@@ -200,6 +200,12 @@ public class RichTextContext: ObservableObject {
      */
     @Published
     public var textAlignment: RichTextAlignment = .left
+    
+    /**
+     Whether or not to disable the scrolling of text view.
+     */
+    @Published
+    public var scrollingDisabled: Bool = false
 }
 
 public extension RichTextContext {

--- a/Sources/RichTextKit/RichTextEditor.swift
+++ b/Sources/RichTextKit/RichTextEditor.swift
@@ -115,7 +115,7 @@ public struct RichTextEditor: ViewRepresentable {
 
     #if os(macOS)
     public func makeNSView(context: Context) -> some NSView {
-        textView.setup(with: text.wrappedValue, format: format)
+        textView.setup(with: text.wrappedValue, format: format, scrollingDisabled: richTextContext.scrollingDisabled)
         viewConfiguration(textView)
         return scrollView
     }

--- a/Sources/RichTextKit/RichTextViewComponent.swift
+++ b/Sources/RichTextKit/RichTextViewComponent.swift
@@ -83,10 +83,12 @@ public protocol RichTextViewComponent: AnyObject,
      - Parameters:
        - text: The text to edit with the text view.
        - format: The rich text format to use.
+       - scrollingDisabled: Disables the scrolling in the NSTextView
      */
     func setup(
         with text: NSAttributedString,
-        format: RichTextDataFormat
+        format: RichTextDataFormat,
+        scrollingDisabled: Bool
     )
 
 
@@ -182,7 +184,7 @@ public extension RichTextViewComponent {
         format: RichTextDataFormat
     ) throws {
         let string = try NSAttributedString(data: data, format: format)
-        setup(with: string, format: format)
+        setup(with: string, format: format, scrollingDisabled: false)
     }
 
     /**

--- a/Sources/RichTextKit/RichTextView_AppKit.swift
+++ b/Sources/RichTextKit/RichTextView_AppKit.swift
@@ -36,7 +36,11 @@ open class RichTextView: NSTextView, RichTextViewComponent {
      with a ``RichTextDataFormat`` that supports images.
      */
     public var imageConfiguration: RichTextImageConfiguration = .disabled
-
+    
+    /**
+     Disables the scrolling in the NSTextView
+     */
+    public var scrollingDisabled: Bool = false
 
     // MARK: - Overrides
 
@@ -64,6 +68,20 @@ open class RichTextView: NSTextView, RichTextViewComponent {
         return super.performDragOperation(draggingInfo)
     }
 
+    
+    open override func scrollWheel(with event: NSEvent)
+    {
+        guard scrollingDisabled else {
+            super.scrollWheel(with: event)
+           return
+        }
+        
+        // 1st nextResponder is NSClipView
+        // 2nd nextResponder is NSScrollView
+        // 3rd nextResponder is NSResponder SwiftUIPlatformViewHost
+        self.nextResponder?.nextResponder?.nextResponder?.scrollWheel(with: event)
+    }
+
 
     // MARK: - Setup
 
@@ -77,8 +95,10 @@ open class RichTextView: NSTextView, RichTextViewComponent {
      */
     open func setup(
         with text: NSAttributedString,
-        format: RichTextDataFormat
+        format: RichTextDataFormat,
+        scrollingDisabled: Bool = false
     ) {
+        self.scrollingDisabled = scrollingDisabled
         attributedString = .empty
         setupInitialFontSize()
         attributedString = text


### PR DESCRIPTION
For my macOS project it is necessary to have a way to turn off the automatic scrolling behavior of the richtext editor because I want to place the richtext editor view in a scroll view between two other view elements. I think this would also be feasible for other users. this could be a solution for that.

Issue: https://github.com/danielsaidi/RichTextKit/issues/118