### PR TITLE
[FIX] ColorPicker foreground color

### DIFF
--- a/Sources/RichTextKit/Coordinator/RichTextCoordinator.swift
+++ b/Sources/RichTextKit/Coordinator/RichTextCoordinator.swift
@@ -222,8 +222,8 @@ extension RichTextCoordinator {
         }
 
         let underline = textView.richTextColor(.underline)
-        if richTextContext.foregroundColor != underline {
-            richTextContext.foregroundColor = underline
+        if richTextContext.underlineColor != underline {
+            richTextContext.underlineColor = underline
         }
 
         let hasRange = textView.hasSelectedRange


### PR DESCRIPTION
# What this PR do:
- Fixes reflection of textColor in RichTextColorPicker

In main branch, try to select text and bring up colorPicker. You can see that probably it doesnt work. This fixes that issue:

<img width="547" alt="Screenshot 2024-01-16 at 15 27 28" src="https://github.com/danielsaidi/RichTextKit/assets/17381941/fc3a0deb-2377-477c-a650-3b2fed2b25a6">
