### PR TITLE
[Feature] Add Theme Config

### DIFF
--- a/Sources/RichTextKit/Component/RichTextViewComponent.swift
+++ b/Sources/RichTextKit/Component/RichTextViewComponent.swift
@@ -133,22 +133,3 @@ public extension RichTextViewComponent {
         format.supportsImages ? .enabled : .disabled
     }
 }
-
-extension RichTextViewComponent {
-
-    /// This can be called to setup the initial font size.
-    func setupInitialFontSize() {
-        let font = FontRepresentable.standardRichTextFont
-        let size = font.pointSize
-        setRichTextFontSize(size)
-    }
-
-    /// This can be called to setup an initial text color.
-    func trySetupInitialTextColor(
-        for text: NSAttributedString,
-        _ action: () -> Void
-    ) {
-        guard text.string.isEmpty else { return }
-        action()
-    }
-}

--- a/Sources/RichTextKit/RichTextView+Theme.swift
+++ b/Sources/RichTextKit/RichTextView+Theme.swift
@@ -1,0 +1,47 @@
+//
+//  RichTextView+Theme.swift
+//  RichTextKit
+//
+//  Created by Dominik Bucher on 13.02.2024.
+//
+
+#if iOS || macOS || os(tvOS) || os(visionOS)
+import SwiftUI
+
+public extension RichTextView {
+
+    /**
+     This type can be used to configure a ``RichTextEditor``'s current color properties.
+     */
+    struct Theme {
+
+        /**
+         Create a custom configuration.
+
+         - Parameters:
+         - font: default `.systemFont` of point size `16` (this differs on iOS and macOS).
+         - fontColor: default `.textColor`.
+         - backgroundColor: Color of whole textView default `.clear`.
+         */
+        public init(
+            font: FontRepresentable = .systemFont(ofSize: 16),
+            fontColor: ColorRepresentable = .textColor,
+            backgroundColor: ColorRepresentable = .clear
+        ) {
+            self.font = font
+            self.fontColor = fontColor
+            self.backgroundColor = backgroundColor
+        }
+
+        public let font: FontRepresentable
+        public let fontColor: ColorRepresentable
+        public let backgroundColor: ColorRepresentable
+    }
+}
+
+public extension RichTextView.Theme {
+
+    /// Get a standard rich text editor configuration.
+    static var standard: Self { .init() }
+}
+#endif

--- a/Sources/RichTextKit/RichTextView_AppKit.swift
+++ b/Sources/RichTextKit/RichTextView_AppKit.swift
@@ -30,6 +30,9 @@ open class RichTextView: NSTextView, RichTextViewComponent {
     /// The configuration to use by the rich text view.
     public var configuration: Configuration = .standard
 
+    /// The theme for coloring and setting style to text view.
+    public var theme: Theme = .standard
+
     /// The style to use when highlighting text in the view.
     public var highlightingStyle: RichTextHighlightingStyle = .standard
 
@@ -107,24 +110,26 @@ open class RichTextView: NSTextView, RichTextViewComponent {
         format: RichTextDataFormat
     ) {
         attributedString = .empty
-        setupInitialFontSize()
         attributedString = text
         allowsImageEditing = true
         allowsUndo = true
-        backgroundColor = .clear
-        trySetupInitialTextColor(for: text) {
-            textColor = .textColor
-        }
         imageConfiguration = standardImageConfiguration(for: format)
         layoutManager?.defaultAttachmentScaling = NSImageScaling.scaleProportionallyDown
         setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
         setupConfiguration()
+        setupTheme()
     }
 
     // MARK: - Internal
 
     func setupConfiguration() {
         isContinuousSpellCheckingEnabled = configuration.isContinuousSpellCheckingEnabled
+    }
+
+    func setupTheme() {
+        font = theme.font
+        textColor = theme.fontColor
+        backgroundColor = theme.backgroundColor
     }
 
     // MARK: - Open Functionality

--- a/Sources/RichTextKit/RichTextView_UIKit.swift
+++ b/Sources/RichTextKit/RichTextView_UIKit.swift
@@ -56,6 +56,12 @@ open class RichTextView: UITextView, RichTextViewComponent {
         }
     }
 
+    public var theme: Theme = .standard {
+        didSet {
+            setupTheme()
+        }
+    }
+
     /// The style to use when highlighting text in the view.
     public var highlightingStyle: RichTextHighlightingStyle = .standard
 
@@ -157,16 +163,22 @@ open class RichTextView: UITextView, RichTextViewComponent {
         format: RichTextDataFormat
     ) {
         attributedString = .empty
-        setupInitialFontSize()
         imageConfiguration = standardImageConfiguration(for: format)
         text.autosizeImageAttachments(maxSize: imageAttachmentMaxSize)
         attributedString = text
         richTextDataFormat = format
-        backgroundColor = .clear
-        trySetupInitialTextColor(for: text) {
-            textColor = .label
-        }
         setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        setupTheme()
+    }
+
+    // MARK: - Internal functionality
+
+    func setupTheme() {
+        if text.isEmpty {
+            font = theme.font
+            textColor = theme.fontColor
+        }
+        backgroundColor = theme.backgroundColor
     }
 
     // MARK: - Open Functionality

--- a/Tests/RichTextKitTests/RichTextViewRepresentableTests.swift
+++ b/Tests/RichTextKitTests/RichTextViewRepresentableTests.swift
@@ -74,9 +74,9 @@ final class RichTextViewComponentTests: XCTestCase {
         XCTAssertEqual(view.contentCompressionResistancePriority(for: .horizontal), .defaultLow)
         #if iOS || os(tvOS)
         XCTAssertEqual(view.spellCheckingType, .no)
-        XCTAssertEqual(view.textColor, nil)
+        XCTAssertEqual(view.textColor, .textColor)
         #elseif macOS
-        XCTAssertEqual(view.textColor, nil)
+        XCTAssertEqual(view.textColor, .textColor)
         #endif
     }
 }


### PR DESCRIPTION
# What this PR do:
- Implements default theme with font, fontColor and background Color for starters
# How to test it
- Run tests (which shouldn't fail) 
- Run app with different Theme configurations
- Try macOS and iOS.


<img width="565" alt="Screenshot 2024-02-13 at 14 13 41" src="https://github.com/danielsaidi/RichTextKit/assets/17381941/64ad492d-a039-46ab-a978-64d67057ac1a">

When non-empty default text, continues in given attributes (tests not broken): 
https://github.com/danielsaidi/RichTextKit/assets/17381941/41af9fb1-0a52-441c-892c-d0a434302817


