### PR TITLE
Fix attributes behaviour on selection change for mac

### DIFF
--- a/Sources/RichTextKit/Component/RichTextViewComponent+Attributes.swift
+++ b/Sources/RichTextKit/Component/RichTextViewComponent+Attributes.swift
@@ -52,4 +52,11 @@ public extension RichTextViewComponent {
             setRichTextAttribute(attribute, to: value)
         }
     }
+
+    /// Replace current attributes with updated one
+    func setNewRichTextAttributes(
+        _ attributes: RichTextAttributes
+    ) {
+        typingAttributes = attributes
+    }
 }

--- a/Sources/RichTextKit/_Foundation/RichTextCoordinator.swift
+++ b/Sources/RichTextKit/_Foundation/RichTextCoordinator.swift
@@ -105,6 +105,7 @@ open class RichTextCoordinator: NSObject {
     }
 
     open func textViewDidChangeSelection(_ notification: Notification) {
+        replaceCurrentAttributesIfNeeded()
         syncWithTextView()
     }
 
@@ -220,6 +221,19 @@ extension RichTextCoordinator {
         if textView.hasSelectedRange { return }
         let attributes = textView.richTextAttributes
         textView.setRichTextAttributes(attributes)
+        #endif
+    }
+
+    /**
+     On macOS, we have to update the typingAttributes when we
+     move the text input cursor and there's no selected text.
+     So that the current attributes will set again for updated location.
+     */
+    func replaceCurrentAttributesIfNeeded() {
+        #if macOS
+        if textView.hasSelectedRange { return }
+        let attributes = textView.richTextAttributes
+        textView.setNewRichTextAttributes(attributes)
         #endif
     }
 }


### PR DESCRIPTION
The issue is happening on Mac only the issue is when we have text with underline or strike-through style, and we move courser from there to somewhere where the text is not having that style and type something it always has that previous attributes from underline or strike-through.

Fix: We need to replace `typingAttributes` with current location's attributes 

The issue : https://github.com/danielsaidi/RichTextKit/issues/217




https://github.com/user-attachments/assets/fabb753e-cae1-4351-b062-4ad201a3f33a

