### PR TITLE
new configuration option for displaying a format sheet button

### DIFF
--- a/Sources/RichTextKit/Keyboard/RichTextKeyboardToolbar+Config.swift
+++ b/Sources/RichTextKit/Keyboard/RichTextKeyboardToolbar+Config.swift
@@ -16,20 +16,25 @@ public struct RichTextKeyboardToolbarConfig {
     ///
     /// - Parameters:
     ///   - alwaysDisplayToolbar: Whether or not to always show the toolbar, by default `false`.
+    ///   - displayFormatSheetButton: Whether to show the format sheet button, by default `true`.
     ///   - leadingActions: The leading actions, by default `.undo` and `.redo`.
     ///   - trailingActions: The trailing actions, by default `.dismissKeyboard`.
     public init(
         alwaysDisplayToolbar: Bool = false,
+        displayFormatSheetButton: Bool = true,
         leadingActions: [RichTextAction] = [.undo, .redo],
-        trailingActions: [RichTextAction] = [.dismissKeyboard]
-    ) {
+        trailingActions: [RichTextAction] = [.dismissKeyboard]) {
         self.alwaysDisplayToolbar = alwaysDisplayToolbar
+        self.displayFormatSheetButton = displayFormatSheetButton
         self.leadingActions = leadingActions
         self.trailingActions = trailingActions
     }
 
     /// Whether or not to always show the toolbar.
     public var alwaysDisplayToolbar: Bool
+    
+    /// Whether to display the format sheet button.
+    public var displayFormatSheetButton: Bool
 
     /// The leading toolbar actions.
     public var leadingActions: [RichTextAction]

--- a/Sources/RichTextKit/Keyboard/RichTextKeyboardToolbar.swift
+++ b/Sources/RichTextKit/Keyboard/RichTextKeyboardToolbar.swift
@@ -181,7 +181,7 @@ private extension RichTextKeyboardToolbar {
 
         divider
 
-     if formatSheetButton {
+     if config.displayFormatSheetButton {
         Button(action: presentFormatSheet) {
             Image.richTextFormat
                 .contentShape(Rectangle())


### PR DESCRIPTION
This pull request includes updates to the `RichTextKeyboardToolbarConfig` and `RichTextKeyboardToolbar` to add a new configuration option for displaying a format sheet button. The most important changes are as follows:

Enhancements to toolbar configuration:

* [`Sources/RichTextKit/Keyboard/RichTextKeyboardToolbar+Config.swift`](diffhunk://#diff-0b5a5fe43f6700dcf82ff12d2d50a1c73ab6e0021941f07af396d27684f74fe5R19-R38): Added a new parameter `displayFormatSheetButton` to the initializer to allow configuration of whether the format sheet button is displayed. This parameter defaults to `true`.
* [`Sources/RichTextKit/Keyboard/RichTextKeyboardToolbar+Config.swift`](diffhunk://#diff-0b5a5fe43f6700dcf82ff12d2d50a1c73ab6e0021941f07af396d27684f74fe5R19-R38): Introduced a new public property `displayFormatSheetButton` to store the configuration value.

Updates to toolbar behavior:

* [`Sources/RichTextKit/Keyboard/RichTextKeyboardToolbar.swift`](diffhunk://#diff-8b8b2e12fea844499a6b8c129e2711239e0e41714b03e5988cf87fb56b776c85R184-R189): Added a conditional check to display the format sheet button based on the `displayFormatSheetButton` configuration value.